### PR TITLE
fix: grepパターンが'-'で始まる場合のオプション誤認識を修正

### DIFF
--- a/apps/changelog-fetcher/src/searchers/grep-executor.ts
+++ b/apps/changelog-fetcher/src/searchers/grep-executor.ts
@@ -23,7 +23,7 @@ function executeGrep(pattern: string, flags: string): string[] {
   try {
     // シングルクォートをエスケープ: 'pattern' -> 'pat'\''tern'
     const escapedPattern = pattern.replace(/'/g, "'\\''");
-    const command = `grep ${flags} '${escapedPattern}' ${DOCS_DIR}/*.md`;
+    const command = `grep ${flags} -- '${escapedPattern}' ${DOCS_DIR}/*.md`;
     const result = execSync(command, { encoding: 'utf-8' });
     return result
       .split('\n')


### PR DESCRIPTION
'--'セパレータを追加し、パターンがgrepオプションとして解釈されることを防ぐ。
v2.1.51 CHANGELOGに含まれる'`-l`'キーワードが原因でgrep: invalid option -- '|' エラーが発生していた問題を修正する。

関連Issue: #35