### PR TITLE
feat: pagefind 全画面検索モーダルとプレフィックス目次を追加

### DIFF
--- a/apps/changelog-fetcher/src/__tests__/inference-prompt.test.ts
+++ b/apps/changelog-fetcher/src/__tests__/inference-prompt.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from 'bun:test';
+import type { ChangelogItem } from '@claude-code-changelog-viewer/types';
+import { buildBatchInferencePrompt } from '../ai/prompts/inference-prompt';
+
+/**
+ * テスト用の ChangelogItem を生成するヘルパー
+ * related_docs の件数で推論対象/翻訳のみ対象が決まるため、
+ * docsCount で制御できるようにしている
+ */
+function makeItem(
+  overrides: Partial<ChangelogItem> & { docsCount?: number } = {},
+): ChangelogItem {
+  const { docsCount = 0, ...rest } = overrides;
+
+  const related_docs = Array.from({ length: docsCount }, (_, i) => ({
+    file: `docs/en/doc${i}.md`,
+    hit_count: 1,
+    context_score: 5,
+    total_score: 6,
+    snippets: [`スニペット${i}`],
+  }));
+
+  return {
+    content: 'Fixed a bug in the login flow',
+    prefix: 'Fixed',
+    importance_score: 4,
+    related_docs,
+    ...rest,
+  };
+}
+
+describe('buildBatchInferencePrompt', () => {
+  describe('推論対象と翻訳対象の振り分け', () => {
+    test('related_docs が 1件以上の項目は推論セクションに含まれる', () => {
+      const items = [makeItem({ docsCount: 1, content: 'Added MCP support' })];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      expect(prompt).toContain('#### 項目 id=0');
+      expect(prompt).toContain('- content: Added MCP support');
+      // 推論セクションに含まれ、翻訳のみセクションには "(対象なし)" が表示される
+      expect(prompt).toContain('# タスク2: 翻訳のみ');
+      expect(prompt).toMatch(/## 対象項目\n\n\(対象なし\)\n\n---\n\n# タスク3/);
+    });
+
+    test('related_docs が 0件の項目は翻訳のみセクションに含まれる', () => {
+      const items = [
+        makeItem({ docsCount: 0, content: 'Fixed typo in README' }),
+      ];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      // 翻訳セクションに含まれる
+      expect(prompt).toContain('# タスク2: 翻訳のみ');
+      expect(prompt).toContain('- content: Fixed typo in README');
+      // 推論セクションには "(対象なし)" が表示される
+      expect(prompt).toMatch(
+        /# タスク1: 推論\+翻訳[\s\S]*?## 対象項目\n\n\(対象なし\)/,
+      );
+    });
+
+    test('複数項目が正しく振り分けられる', () => {
+      const items = [
+        makeItem({ docsCount: 2, prefix: 'Added', content: 'Added hooks' }),
+        makeItem({ docsCount: 0, prefix: 'Fixed', content: 'Fixed crash' }),
+        makeItem({
+          docsCount: 1,
+          prefix: 'Changed',
+          content: 'Changed API',
+        }),
+      ];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      // 推論セクションに id=0 と id=2 が含まれる(related_docs >= 1)
+      expect(prompt).toContain('#### 項目 id=0');
+      expect(prompt).toContain('- content: Added hooks');
+      expect(prompt).toContain('#### 項目 id=2');
+      expect(prompt).toContain('- content: Changed API');
+
+      // 翻訳セクションに id=1 が含まれる(related_docs = 0)
+      expect(prompt).toContain('#### 項目 id=1');
+      expect(prompt).toContain('- content: Fixed crash');
+    });
+  });
+
+  describe('id(インデックス)の保持', () => {
+    test('元の配列インデックスが id として使われる', () => {
+      const items = [
+        makeItem({ docsCount: 0, content: '項目0' }),
+        makeItem({ docsCount: 1, content: '項目1' }),
+        makeItem({ docsCount: 0, content: '項目2' }),
+        makeItem({ docsCount: 2, content: '項目3' }),
+      ];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      // 推論セクション: id=1, id=3(related_docs >= 1)
+      expect(prompt).toContain('#### 項目 id=1\n- prefix:');
+      expect(prompt).toContain('#### 項目 id=3\n- prefix:');
+      // 翻訳セクション: id=0, id=2(related_docs < 1)
+      expect(prompt).toContain('#### 項目 id=0\n- prefix:');
+      expect(prompt).toContain('#### 項目 id=2\n- prefix:');
+    });
+  });
+
+  describe('プロンプト構造', () => {
+    test('バージョン番号がプロンプトに埋め込まれる', () => {
+      const prompt = buildBatchInferencePrompt([], 'v2.1.50', '');
+
+      expect(prompt).toContain('バージョン v2.1.50 の CHANGELOG を処理する');
+    });
+
+    test('modelContext がプロンプトに埋め込まれる', () => {
+      const modelContext =
+        'Claude 4.5 Sonnet (claude-sonnet-4-5-20250514) が最新モデルです';
+
+      const prompt = buildBatchInferencePrompt([], 'v2.1.30', modelContext);
+
+      expect(prompt).toContain(modelContext);
+      expect(prompt).toContain('## Claude Code のモデル情報 (重要)');
+    });
+
+    test('サマリーセクションに全項目のリストが含まれる', () => {
+      const items = [
+        makeItem({ prefix: 'Added', content: 'Added new feature' }),
+        makeItem({ prefix: 'Fixed', content: 'Fixed a bug' }),
+      ];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      expect(prompt).toContain('- [Added] Added new feature');
+      expect(prompt).toContain('- [Fixed] Fixed a bug');
+    });
+
+    test('項目数がプロンプトに含まれる', () => {
+      const items = [makeItem(), makeItem(), makeItem()];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      expect(prompt).toContain('全 3 項目');
+    });
+  });
+
+  describe('関連ドキュメントのスニペット', () => {
+    test('推論対象項目のスニペットがプロンプトに含まれる', () => {
+      const items = [
+        makeItem({
+          docsCount: 0,
+          content: 'Added MCP server support',
+          related_docs: [
+            {
+              file: 'docs/en/mcp.md',
+              hit_count: 3,
+              context_score: 8,
+              total_score: 11,
+              snippets: [
+                'MCP はモデルコンテキストプロトコルです',
+                '設定例: ...',
+              ],
+            },
+            {
+              file: 'docs/en/config.md',
+              hit_count: 1,
+              context_score: 4,
+              total_score: 5,
+              snippets: ['設定ファイルの書き方'],
+            },
+          ],
+        }),
+      ];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      expect(prompt).toContain('### docs/en/mcp.md');
+      expect(prompt).toContain('MCP はモデルコンテキストプロトコルです');
+      expect(prompt).toContain('設定例: ...');
+      expect(prompt).toContain('### docs/en/config.md');
+      expect(prompt).toContain('設定ファイルの書き方');
+    });
+  });
+
+  describe('機能領域タグセクション', () => {
+    test('feature_areas がプロンプトに含まれる', () => {
+      const items = [
+        makeItem({
+          content: 'Added MCP support',
+          feature_areas: ['MCP', 'Settings'],
+        }),
+      ];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      expect(prompt).toContain(
+        'id=0, tags=[MCP, Settings], content: Added MCP support',
+      );
+    });
+
+    test('feature_areas が undefined の項目は空タグとして出力される', () => {
+      const items = [makeItem({ content: 'Some change' })];
+
+      const prompt = buildBatchInferencePrompt(items, 'v2.1.30', '');
+
+      expect(prompt).toContain('id=0, tags=[], content: Some change');
+    });
+  });
+
+  describe('空入力', () => {
+    test('項目が 0件のとき両セクションに "(対象なし)" が出力される', () => {
+      const prompt = buildBatchInferencePrompt([], 'v2.1.30', '');
+
+      // 推論セクションと翻訳セクションの両方に "(対象なし)" が含まれる
+      const matches = prompt.match(/\(対象なし\)/g);
+      expect(matches).toHaveLength(2);
+    });
+
+    test('項目が 0件でも全体構造は維持される', () => {
+      const prompt = buildBatchInferencePrompt([], 'v2.1.30', '');
+
+      expect(prompt).toContain('# タスク1: 推論+翻訳');
+      expect(prompt).toContain('# タスク2: 翻訳のみ');
+      expect(prompt).toContain('# タスク3: サマリー');
+      expect(prompt).toContain('# タスク4: 機能領域タグの補正');
+    });
+  });
+});

--- a/apps/changelog-fetcher/src/ai/prompts/inference-prompt.ts
+++ b/apps/changelog-fetcher/src/ai/prompts/inference-prompt.ts
@@ -13,11 +13,11 @@ export function buildBatchInferencePrompt(
 ): string {
   const inferenceItems = items
     .map((item, index) => ({ item, index }))
-    .filter(({ item }) => item.related_docs.length >= 2);
+    .filter(({ item }) => item.related_docs.length >= 1);
 
   const translationItems = items
     .map((item, index) => ({ item, index }))
-    .filter(({ item }) => item.related_docs.length < 2);
+    .filter(({ item }) => item.related_docs.length < 1);
 
   const inferenceSection = inferenceItems
     .map(({ item, index }) => {

--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -3,6 +3,7 @@
 import partytown from '@astrojs/partytown';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
+import pagefind from 'astro-pagefind';
 import { defineConfig } from 'astro/config';
 // https://astro.build/config
 export default defineConfig({
@@ -28,5 +29,6 @@ export default defineConfig({
         forward: ['dataLayer.push'],
       },
     }),
+    pagefind(),
   ],
 });

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -27,6 +27,7 @@
     "@astrojs/rss": "^4.0.15",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.2.14",
+    "astro-pagefind": "^1.8.5",
     "prettier": "^3.7.4",
     "prettier-plugin-astro": "^0.14.1",
     "tailwindcss": "^4.1.18",

--- a/apps/www/public/_headers
+++ b/apps/www/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://www.google-analytics.com https://notification-worker.ayasnppk00.workers.dev https://static.cloudflareinsights.com; frame-src 'self' https://challenges.cloudflare.com; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://www.google-analytics.com https://notification-worker.ayasnppk00.workers.dev https://static.cloudflareinsights.com; frame-src 'self' https://challenges.cloudflare.com; frame-ancestors 'none'
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff

--- a/apps/www/src/components/SearchModal.astro
+++ b/apps/www/src/components/SearchModal.astro
@@ -1,0 +1,161 @@
+---
+import Search from 'astro-pagefind/components/Search';
+---
+
+<button
+  id='search-trigger'
+  type='button'
+  class='flex items-center gap-2 px-4 py-2 rounded-lg border border-[hsl(var(--cc-gray))] bg-[hsl(var(--cc-main-white))] text-[hsl(var(--cc-main-black)/0.5)] hover:border-[hsl(var(--cc-main-orange))] hover:text-[hsl(var(--cc-main-orange))] transition-colors cursor-pointer text-sm'
+  aria-label='検索を開く (⌘K)'
+>
+  <svg
+    class='w-4 h-4 shrink-0'
+    fill='none'
+    viewBox='0 0 24 24'
+    stroke='currentColor'
+    stroke-width='2'
+    aria-hidden='true'
+  >
+    <path
+      stroke-linecap='round'
+      stroke-linejoin='round'
+      d='M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z'
+    ></path>
+  </svg>
+  <span class='hidden sm:inline text-sm'>検索</span>
+  <kbd
+    class='hidden sm:inline-flex items-center gap-0.5 rounded border border-[hsl(var(--cc-gray))] bg-[hsl(var(--cc-main-white))] px-1.5 py-0.5 text-[11px] font-medium text-[hsl(var(--cc-main-black)/0.4)]'
+  >
+    <span class='text-xs'>⌘</span>K
+  </kbd>
+</button>
+
+<template id='search-modal-template'>
+  <div id='search-modal-overlay' class='search-modal-overlay'>
+    <div class='search-modal-positioner'>
+      <div id='search-modal-content' class='search-modal-content'>
+        <div class='search-modal-header'>
+          <span class='text-sm font-medium text-[hsl(var(--cc-main-black)/0.6)]'
+            >検索</span
+          >
+          <button
+            id='search-modal-close'
+            type='button'
+            class='flex items-center gap-1 text-xs text-[hsl(var(--cc-main-black)/0.4)] hover:text-[hsl(var(--cc-main-black))] transition-colors cursor-pointer'
+            aria-label='検索を閉じる'
+          >
+            <kbd
+              class='rounded border border-[hsl(var(--cc-gray))] bg-[hsl(var(--cc-main-white))] px-1.5 py-0.5 text-[10px] font-medium'
+              >ESC</kbd
+            >
+          </button>
+        </div>
+
+        <div id='search-modal-body' class='search-modal-body'>
+          <Search
+            id='search'
+            className='pagefind-ui'
+            uiOptions={{
+              showImages: false,
+              resetStyles: true,
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+  function initSearchModal() {
+    const trigger = document.getElementById('search-trigger');
+    if (!trigger) {
+      return;
+    }
+
+    let overlay = document.getElementById('search-modal-overlay');
+    if (!overlay) {
+      const template = document.getElementById(
+        'search-modal-template',
+      ) as HTMLTemplateElement | null;
+      if (!template) {
+        return;
+      }
+      const clone = template.content.cloneNode(true);
+      document.body.appendChild(clone);
+      overlay = document.getElementById('search-modal-overlay');
+    }
+    if (!overlay) {
+      return;
+    }
+
+    const content = document.getElementById('search-modal-content');
+    const closeBtn = document.getElementById('search-modal-close');
+    if (!content || !closeBtn) {
+      return;
+    }
+
+    const overlayEl = overlay;
+
+    function openModal() {
+      overlayEl.classList.add('is-open');
+      document.body.style.overflow = 'hidden';
+
+      // 検索入力にフォーカス
+      requestAnimationFrame(() => {
+        const input = overlayEl.querySelector<HTMLInputElement>(
+          '.pagefind-ui__search-input',
+        );
+        input?.focus();
+      });
+    }
+
+    function closeModal() {
+      overlayEl.classList.remove('is-open');
+      document.body.style.overflow = '';
+    }
+
+    // トリガーボタンクリック
+    trigger.addEventListener('click', openModal);
+
+    overlayEl.addEventListener('click', closeModal);
+    content.addEventListener('click', (e) => e.stopPropagation());
+
+    // 閉じるボタン
+    closeBtn.addEventListener('click', closeModal);
+
+    // Cmd+K / Ctrl+K でトグル
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (!overlayEl.classList.contains('is-open')) {
+          openModal();
+        } else {
+          closeModal();
+        }
+      }
+
+      // Escape で閉じる
+      if (e.key === 'Escape' && overlayEl.classList.contains('is-open')) {
+        e.preventDefault();
+        closeModal();
+      }
+    });
+
+    // 検索結果のリンクをクリック時にモーダルを閉じる
+    const modalBody = document.getElementById('search-modal-body');
+    modalBody?.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      const anchor = target.closest('a');
+      if (anchor) {
+        closeModal();
+      }
+    });
+  }
+
+  // 初回ロード
+  initSearchModal();
+
+  // Astro View Transitions 後の再初期化
+  document.addEventListener('astro:after-swap', initSearchModal);
+</script>

--- a/apps/www/src/components/changelog/ChangelogItemCard.astro
+++ b/apps/www/src/components/changelog/ChangelogItemCard.astro
@@ -1,6 +1,11 @@
 ---
 import type { ChangelogItem } from '@claude-code-changelog-viewer/types';
 import { formatChangelogContent } from '../../lib/changelog';
+import {
+  PREFIX_DEFAULT_STYLE,
+  PREFIX_ICONS,
+  PREFIX_STYLES,
+} from '../../lib/prefix';
 import InferenceDetail from './InferenceDetail.astro';
 import RelatedDocsList from './RelatedDocsList.astro';
 
@@ -16,42 +21,20 @@ const formattedContentJa = item.content_ja
   ? formatChangelogContent(item.content_ja)
   : '';
 
-// プレフィックスのスタイルマッピング - Claude オフィシャルカラーで明確に差別化
-const prefixStyles: Record<string, string> = {
-  Added: 'bg-[hsl(var(--cc-main-orange))] text-white shadow-sm',
-  Fixed: 'bg-[hsl(var(--cc-gray))] text-[hsl(var(--cc-main-black))]',
-  Updated: 'bg-[hsl(var(--cc-main-black))] text-[hsl(var(--cc-main-white))]',
-  Changed: 'bg-[hsl(var(--cc-main-black))] text-[hsl(var(--cc-main-white))]',
-  Improved:
-    'border border-[hsl(var(--cc-gray))] text-[hsl(var(--cc-main-black))] bg-[hsl(var(--cc-main-white))]',
-  Removed:
-    'border-2 border-[hsl(var(--cc-main-black))] text-[hsl(var(--cc-main-black))] bg-transparent',
-};
-
-// プレフィックスごとのSVGアイコンパス(色だけでなくアイコンでも区別)
-const prefixIcons: Record<string, string> = {
-  Added: 'M12 4.5v15m7.5-7.5h-15',
-  Fixed:
-    'M11.42 15.17l-4.655-4.655a1 1 0 010-1.414l.354-.354a1 1 0 011.414 0L12 12.21l3.466-3.465a1 1 0 011.414 0l.354.354a1 1 0 010 1.414L12.834 15.17a1 1 0 01-1.414 0z',
-  Updated: 'M4.5 10.5L12 3m0 0l7.5 7.5M12 3v18',
-  Changed:
-    'M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5',
-  Improved:
-    'M2.25 18L9 11.25l4.306 4.306a11.95 11.95 0 015.814-5.518l2.74-1.22m0 0l-5.94-2.281m5.94 2.28l-2.28 5.941',
-  Removed: 'M19.5 12h-15',
-};
-
-const prefixStyle =
-  prefixStyles[item.prefix] ||
-  'border border-[hsl(var(--cc-gray))] text-[hsl(var(--cc-main-black))] bg-[hsl(var(--cc-main-white))]';
-
-const prefixIcon = prefixIcons[item.prefix];
+const prefixStyle = PREFIX_STYLES[item.prefix] || PREFIX_DEFAULT_STYLE;
+const prefixIcon = PREFIX_ICONS[item.prefix];
 ---
 
 <article
   id={anchorId}
   class='changelog-card border border-[hsl(var(--cc-gray))] rounded-lg p-5 bg-white shadow-sm hover:shadow-md transition-all duration-200 hover:border-[hsl(var(--cc-main-orange))]'
+  data-pagefind-filter={`prefix:${item.prefix}`}
 >
+  {
+    (item.feature_areas ?? []).map((area) => (
+      <span class='hidden' data-pagefind-filter={`feature_area:${area}`} />
+    ))
+  }
   <div class='flex-1 min-w-0'>
     <!-- プレフィックスバッジ -->
     {

--- a/apps/www/src/components/changelog/PrefixTableOfContents.astro
+++ b/apps/www/src/components/changelog/PrefixTableOfContents.astro
@@ -1,0 +1,90 @@
+---
+import type { ChangelogItem } from '@claude-code-changelog-viewer/types';
+import {
+  PREFIX_DEFAULT_STYLE,
+  PREFIX_ICONS,
+  PREFIX_STYLES,
+} from '../../lib/prefix';
+
+type PrefixGroup = {
+  prefix: string;
+  label: string;
+  items: { item: ChangelogItem; originalIndex: number }[];
+};
+
+type Props = {
+  groups: PrefixGroup[];
+};
+
+const { groups } = Astro.props;
+
+// 2グループ未満なら表示しない
+const shouldShow = groups.length >= 2;
+---
+
+{
+  shouldShow && (
+    <nav
+      class='mt-5 pt-4 border-t border-[hsl(var(--cc-gray)/0.5)]'
+      aria-label='変更カテゴリ目次'
+    >
+      <h3 class='text-sm font-semibold text-gray-500 mb-3'>カテゴリ</h3>
+      <ul class='space-y-2'>
+        {groups.map((group) => {
+          const style = PREFIX_STYLES[group.prefix] || PREFIX_DEFAULT_STYLE;
+          const iconPath = PREFIX_ICONS[group.prefix];
+          // importance_score が最大のアイテムの content_ja を代表テキストとして使用
+          const representative = group.items.reduce((best, current) =>
+            current.item.importance_score > best.item.importance_score
+              ? current
+              : best,
+          );
+          const repText =
+            representative.item.content_ja || representative.item.content;
+          const truncated =
+            repText.length > 80 ? `${repText.slice(0, 80)}...` : repText;
+
+          return (
+            <li>
+              <a
+                href={`#prefix-${group.prefix.toLowerCase()}`}
+                class='flex items-start gap-3 p-2 -mx-2 rounded-md hover:bg-[hsl(var(--cc-main-orange)/0.05)] transition-colors group'
+              >
+                <span
+                  class={`inline-flex items-center gap-1 shrink-0 px-2 py-0.5 rounded-full text-xs font-bold uppercase ${style}`}
+                >
+                  {iconPath && (
+                    <svg
+                      class='w-3 h-3'
+                      fill='none'
+                      viewBox='0 0 24 24'
+                      stroke='currentColor'
+                      stroke-width='2.5'
+                      aria-hidden='true'
+                    >
+                      <path
+                        stroke-linecap='round'
+                        stroke-linejoin='round'
+                        d={iconPath}
+                      />
+                    </svg>
+                  )}
+                  {group.prefix}
+                </span>
+                <span class='text-sm text-gray-600 leading-snug'>
+                  <span class='font-medium text-[hsl(var(--cc-main-black))]'>
+                    {group.items.length}件
+                  </span>
+                  <span class='mx-1 text-gray-400'>-</span>
+                  <span class='group-hover:text-[hsl(var(--cc-main-black))] transition-colors'>
+                    {truncated}
+                  </span>
+                </span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/www/src/layouts/Layout.astro
+++ b/apps/www/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import { ClientRouter } from 'astro:transitions';
 import Footer from '../components/Footer.astro';
+import SearchModal from '../components/SearchModal.astro';
 import ScrollToTop from '../components/ScrollToTop.astro';
 import { SITE_TITLE } from '../lib/constants';
 import {
@@ -154,6 +155,21 @@ if (breadcrumbs && breadcrumbs.length > 0) {
     </script>
   </head>
   <body>
+    <header
+      class='sticky top-0 z-50 bg-[hsl(var(--cc-main-white)/0.95)] backdrop-blur-sm border-b border-[hsl(var(--cc-gray))]'
+    >
+      <nav
+        class='max-w-6xl mx-auto px-4 h-12 flex items-center justify-between'
+      >
+        <a
+          href='/'
+          class='text-sm font-bold text-[hsl(var(--cc-main-black))] hover:text-[hsl(var(--cc-main-orange))] transition-colors'
+        >
+          Claude Code Changelog
+        </a>
+        <SearchModal />
+      </nav>
+    </header>
     <main>
       <slot />
     </main>

--- a/apps/www/src/lib/prefix.ts
+++ b/apps/www/src/lib/prefix.ts
@@ -1,0 +1,73 @@
+/**
+ * CHANGELOG prefix の表示定義(順序・ラベル・スタイル・アイコン)
+ *
+ * ChangelogItemCard / PrefixTableOfContents / [version].astro で共通利用
+ */
+
+/** 表示順序の配列 */
+export const PREFIX_ORDER = [
+  'Breaking',
+  'Added',
+  'Deprecated',
+  'Changed',
+  'Improved',
+  'Updated',
+  'Removed',
+  'Fixed',
+  'Enabled',
+] as const;
+
+/** 日本語ラベル */
+export const PREFIX_LABELS: Record<string, string> = {
+  Breaking: '破壊的変更',
+  Added: '追加',
+  Deprecated: '非推奨',
+  Changed: '変更',
+  Improved: '改善',
+  Updated: '更新',
+  Removed: '削除',
+  Fixed: '修正',
+  Enabled: '有効化',
+};
+
+/** Tailwind クラス */
+export const PREFIX_STYLES: Record<string, string> = {
+  Breaking: 'bg-red-600 text-white shadow-sm',
+  Added: 'bg-[hsl(var(--cc-main-orange))] text-white shadow-sm',
+  Deprecated: 'border-2 border-yellow-500 text-yellow-700 bg-yellow-50',
+  Changed: 'bg-[hsl(var(--cc-main-black))] text-[hsl(var(--cc-main-white))]',
+  Improved:
+    'border border-[hsl(var(--cc-gray))] text-[hsl(var(--cc-main-black))] bg-[hsl(var(--cc-main-white))]',
+  Updated: 'bg-[hsl(var(--cc-main-black))] text-[hsl(var(--cc-main-white))]',
+  Removed:
+    'border-2 border-[hsl(var(--cc-main-black))] text-[hsl(var(--cc-main-black))] bg-transparent',
+  Fixed: 'bg-[hsl(var(--cc-gray))] text-[hsl(var(--cc-main-black))]',
+  Enabled: 'bg-green-600 text-white shadow-sm',
+};
+
+/** 未定義 prefix 用のフォールバックスタイル */
+export const PREFIX_DEFAULT_STYLE =
+  'border border-[hsl(var(--cc-gray))] text-[hsl(var(--cc-main-black))] bg-[hsl(var(--cc-main-white))]';
+
+/** SVG パス(stroke アイコン) */
+export const PREFIX_ICONS: Record<string, string> = {
+  Breaking:
+    'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z',
+  Added: 'M12 4.5v15m7.5-7.5h-15',
+  Deprecated: 'M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z',
+  Changed:
+    'M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5',
+  Improved:
+    'M2.25 18L9 11.25l4.306 4.306a11.95 11.95 0 015.814-5.518l2.74-1.22m0 0l-5.94-2.281m5.94 2.28l-2.28 5.941',
+  Updated: 'M4.5 10.5L12 3m0 0l7.5 7.5M12 3v18',
+  Removed: 'M19.5 12h-15',
+  Fixed:
+    'M11.42 15.17l-4.655-4.655a1 1 0 010-1.414l.354-.354a1 1 0 011.414 0L12 12.21l3.466-3.465a1 1 0 011.414 0l.354.354a1 1 0 010 1.414L12.834 15.17a1 1 0 01-1.414 0z',
+  Enabled: 'M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z',
+};
+
+/** ソート用ヘルパー: PREFIX_ORDER のインデックスを返す(未定義は末尾) */
+export function getPrefixSortOrder(prefix: string): number {
+  const idx = (PREFIX_ORDER as readonly string[]).indexOf(prefix);
+  return idx === -1 ? PREFIX_ORDER.length : idx;
+}

--- a/apps/www/src/pages/changelog/[version].astro
+++ b/apps/www/src/pages/changelog/[version].astro
@@ -1,8 +1,16 @@
 ---
 import { getCollection } from 'astro:content';
 import ChangelogItemCard from '../../components/changelog/ChangelogItemCard.astro';
+import PrefixTableOfContents from '../../components/changelog/PrefixTableOfContents.astro';
 import Layout from '../../layouts/Layout.astro';
 import { formatChangelogContent } from '../../lib/changelog';
+import {
+  PREFIX_DEFAULT_STYLE,
+  PREFIX_ICONS,
+  PREFIX_LABELS,
+  PREFIX_STYLES,
+  getPrefixSortOrder,
+} from '../../lib/prefix';
 import { semverCompareDesc } from '../../lib/semver';
 
 export async function getStaticPaths() {
@@ -58,10 +66,37 @@ const description =
 // summaryのバッククォートをHTMLコードタグに変換
 const formattedSummary = summary ? formatChangelogContent(summary) : undefined;
 
-// 元のインデックスを保持しつつ重要度降順でソート
-const sortedItems = items
-  .map((item, index) => ({ item, originalIndex: index }))
-  .sort((a, b) => b.item.importance_score - a.item.importance_score);
+// prefix でグルーピング + グループ内 importance_score 降順
+const itemsWithIndex = items.map((item, index) => ({
+  item,
+  originalIndex: index,
+}));
+
+const groupMap = new Map<string, typeof itemsWithIndex>();
+for (const entry of itemsWithIndex) {
+  const key = entry.item.prefix;
+  if (!groupMap.has(key)) {
+    groupMap.set(key, []);
+  }
+  const group = groupMap.get(key);
+  if (group) {
+    group.push(entry);
+  }
+}
+for (const group of groupMap.values()) {
+  group.sort((a, b) => b.item.importance_score - a.item.importance_score);
+}
+
+const prefixGroups = [...groupMap.entries()]
+  .sort(([a], [b]) => getPrefixSortOrder(a) - getPrefixSortOrder(b))
+  .map(([prefix, groupItems]) => ({
+    prefix,
+    label: PREFIX_LABELS[prefix] ?? prefix,
+    items: groupItems,
+  }));
+
+// フラットリスト(件数表示用)
+const totalItemCount = items.length;
 ---
 
 <Layout
@@ -77,9 +112,9 @@ const sortedItems = items
     },
   ]}
 >
-  <div class='min-h-dvh py-12 sm:py-16 px-4'>
+  <div class='min-h-dvh py-12 sm:py-16 px-4' data-pagefind-body>
     <div class='max-w-4xl mx-auto'>
-      <nav class='mb-8' aria-label='パンくずリスト'>
+      <nav class='mb-8' aria-label='パンくずリスト' data-pagefind-ignore>
         <a
           href='/'
           data-direction='back'
@@ -106,13 +141,14 @@ const sortedItems = items
         <h1
           class='text-3xl sm:text-4xl font-bold text-balance text-[hsl(var(--cc-main-black))] mb-3'
           transition:name={`version-title-${version}`}
+          data-pagefind-meta='title'
         >
           Claude Code v{version}
         </h1>
         <div
           class='flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600'
         >
-          <p>変更項目: {sortedItems.length}件</p>
+          <p>変更項目: {totalItemCount}件</p>
           {
             hasGitHubRelease && (
               <a
@@ -154,18 +190,58 @@ const sortedItems = items
                 set:html={formattedSummary}
               />
             </div>
+            <PrefixTableOfContents groups={prefixGroups} />
           </div>
         )
       }
 
-      <h2 class='text-xl font-bold text-[hsl(var(--cc-main-black))] mb-6'>
-        変更内容一覧
-      </h2>
-      <div class='space-y-6'>
+      <div class='space-y-10'>
         {
-          sortedItems.map(({ item, originalIndex }) => (
-            <ChangelogItemCard item={item} anchorId={`item-${originalIndex}`} />
-          ))
+          prefixGroups.map((group) => {
+            const style = PREFIX_STYLES[group.prefix] || PREFIX_DEFAULT_STYLE;
+            const iconPath = PREFIX_ICONS[group.prefix];
+            return (
+              <section id={`prefix-${group.prefix.toLowerCase()}`}>
+                <div class='sticky top-0 z-10 bg-white/95 backdrop-blur-sm py-3 -mx-4 px-4 mb-4 border-b border-[hsl(var(--cc-gray)/0.3)]'>
+                  <h3 class='flex items-center gap-2 text-lg font-bold text-[hsl(var(--cc-main-black))]'>
+                    <span
+                      class={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-bold uppercase ${style}`}
+                    >
+                      {iconPath && (
+                        <svg
+                          class='w-3.5 h-3.5'
+                          fill='none'
+                          viewBox='0 0 24 24'
+                          stroke='currentColor'
+                          stroke-width='2.5'
+                          aria-hidden='true'
+                        >
+                          <path
+                            stroke-linecap='round'
+                            stroke-linejoin='round'
+                            d={iconPath}
+                          />
+                        </svg>
+                      )}
+                      {group.prefix}
+                    </span>
+                    <span>{group.label}</span>
+                    <span class='text-sm font-normal text-gray-500'>
+                      ({group.items.length}件)
+                    </span>
+                  </h3>
+                </div>
+                <div class='space-y-6'>
+                  {group.items.map(({ item, originalIndex }) => (
+                    <ChangelogItemCard
+                      item={item}
+                      anchorId={`item-${originalIndex}`}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })
         }
       </div>
 

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -14,6 +14,16 @@
 }
 
 @layer base {
+  /* Pagefind UI カスタムプロパティ */
+  :root {
+    --pagefind-ui-primary: hsl(var(--cc-main-orange));
+    --pagefind-ui-text: hsl(var(--cc-main-black));
+    --pagefind-ui-background: hsl(var(--cc-main-white));
+    --pagefind-ui-border: hsl(var(--cc-gray));
+    --pagefind-ui-border-radius: 8px;
+    --pagefind-ui-font: inherit;
+  }
+
   body {
     @apply bg-[hsl(var(--cc-main-white))] text-[hsl(var(--cc-main-black))];
   }
@@ -208,4 +218,167 @@
   body {
     @apply bg-background text-foreground;
   }
+}
+
+/*
+ * 検索モーダル
+ * @layer 外に配置: pagefind が動的生成する DOM に確実に勝つため
+ */
+
+/* モーダル オーバーレイ(body 直下に JS で移動済み)
+ * overlay 自身に背景・ぼかしを直接指定する。
+ * 子要素に別の backdrop div を作ると fixed 内で描画が限定される。
+ */
+.search-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: none;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.search-modal-overlay.is-open {
+  display: block;
+}
+
+/* モーダル位置決め */
+.search-modal-positioner {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  padding: 10vh 1rem 0;
+}
+
+@media (min-width: 640px) {
+  .search-modal-positioner {
+    padding-top: 15vh;
+  }
+}
+
+/* モーダル本体 */
+.search-modal-content {
+  width: 100%;
+  max-width: 42rem;
+  max-height: 70vh;
+  overflow-y: auto;
+  border-radius: 12px;
+  border: 1px solid hsl(var(--cc-gray));
+  background: hsl(var(--cc-main-white));
+  box-shadow:
+    0 25px 50px -12px rgba(0, 0, 0, 0.25),
+    0 0 0 1px rgba(0, 0, 0, 0.05);
+}
+
+/* モーダルヘッダー */
+.search-modal-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid hsl(var(--cc-gray));
+  background: hsl(var(--cc-main-white));
+}
+
+/* モーダルボディ */
+.search-modal-body {
+  padding: 1rem;
+}
+
+/* --- Pagefind UI(モーダル内)--- */
+
+/* form を relative にして ::before(虫眼鏡)を絶対配置の基点にする */
+.search-modal-body .pagefind-ui__form {
+  position: relative !important;
+}
+
+/* 虫眼鏡アイコン: 入力欄の左側・垂直中央に固定
+ * top: 50% は使わない — form は結果ドロワーも含むため
+ * 結果表示時に form が伸びると 50% の基準点が下にずれる。
+ * input 高さ 2.75rem の中央 = 1.375rem を直接指定する。
+ */
+.search-modal-body .pagefind-ui__form::before {
+  content: "" !important;
+  position: absolute !important;
+  top: 1.375rem !important;
+  left: 0.75rem !important;
+  transform: translateY(-50%) !important;
+  width: 1.125rem !important;
+  height: 1.125rem !important;
+  z-index: 1 !important;
+  /* pagefind デフォルトの background-image を継承 */
+}
+
+/* 検索入力欄 */
+.search-modal-body .pagefind-ui__search-input {
+  font-size: 1rem !important;
+  height: 2.75rem !important;
+  border-radius: 8px !important;
+  padding-left: 2.5rem !important;
+  width: 100% !important;
+  box-sizing: border-box !important;
+  background: hsl(var(--cc-main-white)) !important;
+  border: 1px solid hsl(var(--cc-gray)) !important;
+  outline: none !important;
+}
+
+.search-modal-body .pagefind-ui__search-input:focus {
+  border-color: hsl(var(--cc-main-orange)) !important;
+  box-shadow: 0 0 0 1px hsl(var(--cc-main-orange) / 0.3) !important;
+}
+
+/* クリアボタンの垂直中央配置
+ * 虫眼鏡と同様に input 高さ基準の固定値を使用
+ */
+.search-modal-body .pagefind-ui__search-clear {
+  top: 1.375rem !important;
+  transform: translateY(-50%) !important;
+  right: 0.75rem !important;
+  background: transparent !important;
+  color: hsl(var(--cc-main-black) / 0.4) !important;
+}
+
+.search-modal-body .pagefind-ui__search-clear:hover {
+  color: hsl(var(--cc-main-black)) !important;
+}
+
+/* 検索結果リンク */
+.search-modal-body .pagefind-ui__result-link {
+  color: hsl(var(--cc-main-black)) !important;
+  font-weight: 600 !important;
+}
+
+.search-modal-body .pagefind-ui__result-link:hover {
+  color: hsl(var(--cc-main-orange)) !important;
+}
+
+/* 検索結果ハイライト */
+.search-modal-body mark {
+  background-color: hsl(var(--cc-main-orange) / 0.2) !important;
+  color: inherit !important;
+  border-radius: 2px;
+  padding: 0 2px;
+}
+
+/* 検索結果の各アイテム */
+.search-modal-body .pagefind-ui__result {
+  border-bottom: 1px solid hsl(var(--cc-gray)) !important;
+  padding: 0.75rem 0 !important;
+}
+
+.search-modal-body .pagefind-ui__result:last-child {
+  border-bottom: none !important;
+}
+
+/* pagefind が動的生成する要素の背景色を --cc-main-white に統一
+ * デフォルトの純白 (#fff) がモーダル背景 (#FAF9F5) と差異を生むのを防ぐ
+ */
+.search-modal-body .pagefind-ui__drawer,
+.search-modal-body .pagefind-ui__results-area,
+.search-modal-body .pagefind-ui__filter-panel {
+  background: transparent !important;
 }

--- a/apps/www/wrangler.jsonc
+++ b/apps/www/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "claude-code-changelog-viewer",
+  "workers_dev": true,
   "compatibility_date": "2026-01-30",
   "assets": {
     "directory": "./dist"

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
         "@astrojs/rss": "^4.0.15",
         "@tailwindcss/vite": "^4.1.18",
         "@types/react": "^19.2.14",
+        "astro-pagefind": "^1.8.5",
         "prettier": "^3.7.4",
         "prettier-plugin-astro": "^0.14.1",
         "tailwindcss": "^4.1.18",
@@ -387,7 +388,23 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NxErbI1TmJEZZVvGPePjgXFZCuOzrjQuJ6YwHjcWkelReK7Uhg4QeL05zRdfTpgkH6IY/C8OjbKx5ZilQ4yDFg=="],
 
+    "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ=="],
+
+    "@pagefind/darwin-x64": ["@pagefind/darwin-x64@1.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A=="],
+
+    "@pagefind/default-ui": ["@pagefind/default-ui@1.4.0", "", {}, "sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ=="],
+
+    "@pagefind/freebsd-x64": ["@pagefind/freebsd-x64@1.4.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q=="],
+
+    "@pagefind/linux-arm64": ["@pagefind/linux-arm64@1.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw=="],
+
+    "@pagefind/linux-x64": ["@pagefind/linux-x64@1.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg=="],
+
+    "@pagefind/windows-x64": ["@pagefind/windows-x64@1.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -618,6 +635,8 @@
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
     "astro": ["astro@5.18.0", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.5", "@astrojs/markdown-remark": "6.3.10", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.3", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.3", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-CHiohwJIS4L0G6/IzE1Fx3dgWqXBCXus/od0eGUfxrZJD2um2pE7ehclMmgL/fXqbU7NfE1Ze2pq34h2QaA6iQ=="],
+
+    "astro-pagefind": ["astro-pagefind@1.8.5", "", { "dependencies": { "@pagefind/default-ui": "^1.2.0", "pagefind": "^1.2.0", "sirv": "^3.0.0" }, "peerDependencies": { "astro": "^2.0.4 || ^3 || ^4 || ^5" } }, "sha512-CVhKKA9bTQ7hLsHk9KTNDzOdgR4EI04gn0mjDGfnXzaHx7rL92YkNpFM5AoFl9NWmOUbaIFC2DN7Yvs/ZFPRdA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -1139,6 +1158,8 @@
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
+    "pagefind": ["pagefind@1.4.0", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.4.0", "@pagefind/darwin-x64": "1.4.0", "@pagefind/freebsd-x64": "1.4.0", "@pagefind/linux-arm64": "1.4.0", "@pagefind/linux-x64": "1.4.0", "@pagefind/windows-x64": "1.4.0" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g=="],
+
     "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
     "parse-css-color": ["parse-css-color@0.2.1", "", { "dependencies": { "color-name": "^1.1.4", "hex-rgb": "^4.1.0" } }, "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg=="],
@@ -1261,6 +1282,8 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "sitemap": ["sitemap@8.0.2", "", { "dependencies": { "@types/node": "^17.0.5", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/cli.js" } }, "sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ=="],
@@ -1306,6 +1329,8 @@
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 


### PR DESCRIPTION
- ヘッダーの検索UIをトリガーボタン＋全画面オーバーレイモーダルに刷新
  - template + cloneNode で body 直下に配置しスタッキングコンテキスト問題を解決
  - ⌘K / Ctrl+K トグル、ESC・背景クリックで閉じる
  - pagefind アイコン位置を固定値で指定し結果表示時のズレを修正
  - 枠線・クリアボタン・フォーカスリングをテーマカラーに統一
- バージョン詳細ページにプレフィックス別目次(PrefixTableOfContents)を追加
- prefix スタイル定義を lib/prefix.ts に切り出し ChangelogItemCard から参照
- inference-prompt の related_docs 閾値を 2 → 1 に変更
- CSP に wasm-unsafe-eval を追加(pagefind の WASM 実行に必要)
- astro-pagefind パッケージを追加