### PR TITLE
feat: feature_areas 別集約ページを追加

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -11,7 +11,8 @@
     "upload": "wrangler versions upload --minify",
     "astro": "astro",
     "format": "prettier --write '**/*.astro'",
-    "check": "astro check"
+    "check": "astro check",
+    "test": "bun test"
   },
   "dependencies": {
     "@astrojs/partytown": "^2.1.4",

--- a/apps/www/src/components/Footer.astro
+++ b/apps/www/src/components/Footer.astro
@@ -102,6 +102,28 @@
           </li>
           <li>
             <a
+              href='/features'
+              class='text-sm text-[hsl(var(--cc-main-black)/0.7)] hover:text-[hsl(var(--cc-main-orange))] transition-colors inline-flex items-center gap-2.5'
+            >
+              <svg
+                class='w-4 h-4'
+                fill='none'
+                viewBox='0 0 24 24'
+                stroke='currentColor'
+                stroke-width='2'
+                aria-hidden='true'
+              >
+                <path
+                  stroke-linecap='round'
+                  stroke-linejoin='round'
+                  d='M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z'
+                ></path>
+              </svg>
+              機能エリア別の変更履歴
+            </a>
+          </li>
+          <li>
+            <a
               href='/rss.xml'
               class='text-sm text-[hsl(var(--cc-main-black)/0.7)] hover:text-[hsl(var(--cc-main-orange))] transition-colors inline-flex items-center gap-2.5'
             >

--- a/apps/www/src/components/changelog/ChangelogItemCard.astro
+++ b/apps/www/src/components/changelog/ChangelogItemCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { ChangelogItem } from '@claude-code-changelog-viewer/types';
 import { formatChangelogContent } from '../../lib/changelog';
+import { getFeatureAreaLabel, toFeatureAreaSlug } from '../../lib/feature-area';
 import {
   PREFIX_DEFAULT_STYLE,
   PREFIX_ICONS,
@@ -12,9 +13,11 @@ import RelatedDocsList from './RelatedDocsList.astro';
 type Props = {
   item: ChangelogItem;
   anchorId?: string;
+  /** ページが存在する feature_area の Set(未指定時はリンクを生成しない) */
+  linkedAreas?: Set<string>;
 };
 
-const { item, anchorId } = Astro.props;
+const { item, anchorId, linkedAreas } = Astro.props;
 const formattedContent = formatChangelogContent(item.content);
 const hasJaTranslation = !!item.content_ja;
 const formattedContentJa = item.content_ja
@@ -30,11 +33,6 @@ const prefixIcon = PREFIX_ICONS[item.prefix];
   class='changelog-card border border-[hsl(var(--cc-gray))] rounded-lg p-5 bg-white shadow-sm hover:shadow-md transition-all duration-200 hover:border-[hsl(var(--cc-main-orange))]'
   data-pagefind-filter={`prefix:${item.prefix}`}
 >
-  {
-    (item.feature_areas ?? []).map((area) => (
-      <span class='hidden' data-pagefind-filter={`feature_area:${area}`} />
-    ))
-  }
   <div class='flex-1 min-w-0'>
     <!-- プレフィックスバッジ -->
     {
@@ -61,6 +59,31 @@ const prefixIcon = PREFIX_ICONS[item.prefix];
             )}
             {item.prefix}
           </span>
+        </div>
+      )
+    }
+
+    {
+      (item.feature_areas ?? []).length > 0 && (
+        <div class='flex flex-wrap gap-1.5 mb-3'>
+          {(item.feature_areas ?? []).map((area) =>
+            linkedAreas?.has(area) ? (
+              <a
+                href={`/features/${toFeatureAreaSlug(area)}`}
+                class='inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-[hsl(var(--cc-gray)/0.5)] text-[hsl(var(--cc-main-black)/0.6)] hover:bg-[hsl(var(--cc-main-orange)/0.1)] hover:text-[hsl(var(--cc-main-orange))] transition-colors'
+                data-pagefind-filter={`feature_area:${area}`}
+              >
+                {getFeatureAreaLabel(area)}
+              </a>
+            ) : (
+              <span
+                class='inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-[hsl(var(--cc-gray)/0.5)] text-[hsl(var(--cc-main-black)/0.6)]'
+                data-pagefind-filter={`feature_area:${area}`}
+              >
+                {getFeatureAreaLabel(area)}
+              </span>
+            ),
+          )}
         </div>
       )
     }

--- a/apps/www/src/components/changelog/FeatureAreaCard.astro
+++ b/apps/www/src/components/changelog/FeatureAreaCard.astro
@@ -1,0 +1,39 @@
+---
+type Props = {
+  slug: string;
+  label: string;
+  itemCount: number;
+  versionCount: number;
+};
+
+const { slug, label, itemCount, versionCount } = Astro.props;
+---
+
+<a
+  href={`/features/${slug}`}
+  class='version-card block bg-card text-card-foreground rounded-xl border shadow-sm hover:shadow-lg hover:border-[hsl(var(--cc-main-orange))] transition-all duration-200 overflow-hidden group cursor-pointer'
+>
+  <div class='p-6 flex items-center justify-between'>
+    <div>
+      <h2
+        class='text-2xl font-bold text-[hsl(var(--cc-main-orange))] mb-1 group-hover:text-[hsl(var(--cc-orange-hover))] transition-colors'
+      >
+        {label}
+      </h2>
+      <p class='text-sm text-muted-foreground'>
+        {itemCount}件の変更 / {versionCount}バージョン
+      </p>
+    </div>
+    <svg
+      class='w-5 h-5 text-[hsl(var(--cc-gray))] group-hover:text-[hsl(var(--cc-main-orange))] group-hover:translate-x-1 transition-all duration-200 shrink-0'
+      fill='none'
+      viewBox='0 0 24 24'
+      stroke='currentColor'
+      stroke-width='2'
+      aria-hidden='true'
+    >
+      <path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'
+      ></path>
+    </svg>
+  </div>
+</a>

--- a/apps/www/src/layouts/Layout.astro
+++ b/apps/www/src/layouts/Layout.astro
@@ -8,13 +8,15 @@ import { SITE_TITLE } from '../lib/constants';
 import {
   generateWebSiteJsonLd,
   generateArticleJsonLd,
+  generateCollectionPageJsonLd,
   generateBreadcrumbJsonLd,
 } from '../lib/json-ld';
 
 type JsonLdData =
   | { type: 'website' }
   | { type: 'article'; version: string; summary?: string }
-  | { type: 'page' };
+  | { type: 'page' }
+  | { type: 'collection'; title: string; description: string };
 
 type BreadcrumbItem = {
   name: string;
@@ -59,6 +61,17 @@ if (jsonLd?.type === 'website') {
         description: pageDescription,
         url: canonicalUrl,
         version: jsonLd.version,
+      }),
+    ),
+  );
+} else if (jsonLd?.type === 'collection') {
+  jsonLdScripts.push(
+    JSON.stringify(
+      generateCollectionPageJsonLd({
+        siteUrl,
+        title: jsonLd.title,
+        description: jsonLd.description,
+        url: canonicalUrl,
       }),
     ),
   );

--- a/apps/www/src/lib/__tests__/feature-area.test.ts
+++ b/apps/www/src/lib/__tests__/feature-area.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test';
+import type { ChangelogItem } from '@claude-code-changelog-viewer/types';
+import {
+  aggregateByFeatureArea,
+  findAreaBySlug,
+  groupByVersion,
+  toFeatureAreaSlug,
+  validateSlugUniqueness,
+} from '../feature-area';
+
+// 実データの全14エリア
+const ALL_AREAS = [
+  'Settings',
+  'IDE/VSCode',
+  'Memory',
+  'Skills',
+  'Permissions',
+  'MCP',
+  'Hooks',
+  'Plugins',
+  'Sub-agents',
+  'Agent Teams',
+  'Plan',
+  'SDK',
+  'Tasks',
+  'CLI',
+];
+
+function makeItem(overrides: Partial<ChangelogItem> = {}): ChangelogItem {
+  return {
+    content: 'test content',
+    prefix: 'Added',
+    importance_score: 5,
+    related_docs: [],
+    ...overrides,
+  };
+}
+
+describe('toFeatureAreaSlug', () => {
+  test('スラッシュをハイフンに変換する', () => {
+    expect(toFeatureAreaSlug('IDE/VSCode')).toBe('ide-vscode');
+  });
+
+  test('既存ハイフンを保持する', () => {
+    expect(toFeatureAreaSlug('Sub-agents')).toBe('sub-agents');
+  });
+
+  test('スペースをハイフンに変換する', () => {
+    expect(toFeatureAreaSlug('Agent Teams')).toBe('agent-teams');
+  });
+
+  test('単純な小文字化', () => {
+    expect(toFeatureAreaSlug('MCP')).toBe('mcp');
+    expect(toFeatureAreaSlug('Settings')).toBe('settings');
+  });
+
+  test('全14エリアで一意なスラッグが生成される', () => {
+    const slugs = ALL_AREAS.map(toFeatureAreaSlug);
+    expect(new Set(slugs).size).toBe(ALL_AREAS.length);
+  });
+});
+
+describe('findAreaBySlug', () => {
+  test('全14エリアについて往復整合性が成立する', () => {
+    for (const area of ALL_AREAS) {
+      const slug = toFeatureAreaSlug(area);
+      expect(findAreaBySlug(slug, ALL_AREAS)).toBe(area);
+    }
+  });
+
+  test('存在しないスラッグは undefined を返す', () => {
+    expect(findAreaBySlug('unknown', ALL_AREAS)).toBeUndefined();
+  });
+});
+
+describe('aggregateByFeatureArea', () => {
+  test('複数エリアに属するアイテムは両方に出現する', () => {
+    const changelogs = [
+      {
+        version: '2.1.0',
+        items: [makeItem({ feature_areas: ['MCP', 'Hooks'] })],
+      },
+    ];
+
+    const result = aggregateByFeatureArea(changelogs);
+    expect(result.get('MCP')?.length).toBe(1);
+    expect(result.get('Hooks')?.length).toBe(1);
+  });
+
+  test('feature_areas が空配列のアイテムはどのエリアにも含まれない', () => {
+    const changelogs = [
+      {
+        version: '2.1.0',
+        items: [makeItem({ feature_areas: [] })],
+      },
+    ];
+
+    const result = aggregateByFeatureArea(changelogs);
+    expect(result.size).toBe(0);
+  });
+
+  test('feature_areas が未設定のアイテムはどのエリアにも含まれない', () => {
+    const changelogs = [
+      {
+        version: '2.1.0',
+        items: [makeItem({ feature_areas: undefined })],
+      },
+    ];
+
+    const result = aggregateByFeatureArea(changelogs);
+    expect(result.size).toBe(0);
+  });
+
+  test('2つのバージョンの同じエリアのアイテムが正しく合算される', () => {
+    const changelogs = [
+      {
+        version: '2.1.0',
+        items: [makeItem({ feature_areas: ['MCP'] })],
+      },
+      {
+        version: '2.0.0',
+        items: [
+          makeItem({ feature_areas: ['MCP'] }),
+          makeItem({ feature_areas: ['MCP'] }),
+        ],
+      },
+    ];
+
+    const result = aggregateByFeatureArea(changelogs);
+    expect(result.get('MCP')?.length).toBe(3);
+  });
+});
+
+describe('groupByVersion', () => {
+  // semverCompareDesc と同じ比較関数
+  const compareFn = (a: string, b: string): number => {
+    const pa = a.split('.').map(Number);
+    const pb = b.split('.').map(Number);
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+      const diff = (pb.at(i) ?? 0) - (pa.at(i) ?? 0);
+      if (diff !== 0) {
+        return diff;
+      }
+    }
+    return 0;
+  };
+
+  test('バージョン降順でグループが並ぶ', () => {
+    const items = [
+      { version: '2.0.0', item: makeItem() },
+      { version: '2.1.63', item: makeItem() },
+      { version: '2.1.60', item: makeItem() },
+    ];
+
+    const groups = groupByVersion(items, compareFn);
+    expect(groups.map((g) => g.version)).toEqual(['2.1.63', '2.1.60', '2.0.0']);
+  });
+
+  test('同一バージョン内のアイテムが importance_score 降順で並ぶ', () => {
+    const items = [
+      { version: '2.1.0', item: makeItem({ importance_score: 3 }) },
+      { version: '2.1.0', item: makeItem({ importance_score: 8 }) },
+      { version: '2.1.0', item: makeItem({ importance_score: 5 }) },
+    ];
+
+    const groups = groupByVersion(items, compareFn);
+    expect(groups[0].items.map((i) => i.importance_score)).toEqual([8, 5, 3]);
+  });
+});
+
+describe('validateSlugUniqueness', () => {
+  test('全エリアが一意のスラッグを持つ場合、エラーを throw しない', () => {
+    expect(() => validateSlugUniqueness(ALL_AREAS)).not.toThrow();
+  });
+
+  test('同じスラッグになる入力で Error を throw する', () => {
+    expect(() => validateSlugUniqueness(['VS Code', 'VS/Code'])).toThrow(
+      /スラッグが衝突/,
+    );
+  });
+});

--- a/apps/www/src/lib/feature-area.ts
+++ b/apps/www/src/lib/feature-area.ts
@@ -1,0 +1,160 @@
+/**
+ * feature_areas 別集約ページのユーティリティ
+ *
+ * スラッグ変換・ラベル・説明文・データ集約・衝突検出を提供。
+ * features/index.astro / features/[area].astro / ChangelogItemCard で共通利用
+ */
+
+import type { ChangelogItem } from '@claude-code-changelog-viewer/types';
+
+/** ページ生成に必要な最小アイテム数(これ未満のエリアはページを生成しない) */
+export const MIN_ITEMS_FOR_PAGE = 3;
+
+/** 決定的な変換: lowercase + スラッシュ/スペース → ハイフン */
+export function toFeatureAreaSlug(area: string): string {
+  return area.toLowerCase().replace(/[/\s]+/g, '-');
+}
+
+/** スラッグから元の feature_area 名を逆引き */
+export function findAreaBySlug(
+  slug: string,
+  allAreas: string[],
+): string | undefined {
+  return allAreas.find((area) => toFeatureAreaSlug(area) === slug);
+}
+
+/** 表示ラベル(公式名称をそのまま使用) */
+export const FEATURE_AREA_LABELS: Record<string, string> = {
+  Settings: 'Settings',
+  'IDE/VSCode': 'IDE / VSCode',
+  Memory: 'Memory',
+  Skills: 'Skills',
+  Permissions: 'Permissions',
+  MCP: 'MCP',
+  Hooks: 'Hooks',
+  Plugins: 'Plugins',
+  'Sub-agents': 'Sub-agents',
+  'Agent Teams': 'Agent Teams',
+  Plan: 'Plan',
+  SDK: 'SDK',
+  Tasks: 'Tasks',
+  CLI: 'CLI',
+};
+
+/** SEO description */
+const FEATURE_AREA_DESCRIPTIONS: Record<string, string> = {
+  Settings:
+    'Claude CodeのSettingsに関する全バージョンの変更履歴。CLAUDE.md、.clauderc、環境変数などの設定変更をバージョン横断で確認できます。',
+  'IDE/VSCode':
+    'Claude CodeのIDE/VSCode連携に関する全バージョンの変更履歴。エディタ統合、拡張機能、ワークスペース対応の変更をバージョン横断で確認できます。',
+  Memory:
+    'Claude CodeのMemory機能に関する全バージョンの変更履歴。コンテキスト管理、会話履歴、自動記憶の変更をバージョン横断で確認できます。',
+  Skills:
+    'Claude CodeのSkills機能に関する全バージョンの変更履歴。カスタムスキル、スラッシュコマンド、スキル管理の変更をバージョン横断で確認できます。',
+  Permissions:
+    'Claude CodeのPermissions機能に関する全バージョンの変更履歴。ツール許可、セキュリティ設定、承認フローの変更をバージョン横断で確認できます。',
+  MCP: 'Claude CodeのMCP(Model Context Protocol)に関する全バージョンの変更履歴。MCPサーバー、ツール統合、プロトコル対応の変更をバージョン横断で確認できます。',
+  Hooks:
+    'Claude CodeのHooks機能に関する全バージョンの変更履歴。カスタムフック、イベントトリガー、自動化の変更をバージョン横断で確認できます。',
+  Plugins:
+    'Claude CodeのPlugins機能に関する全バージョンの変更履歴。プラグイン管理、サードパーティ統合の変更をバージョン横断で確認できます。',
+  'Sub-agents':
+    'Claude CodeのSub-agents機能に関する全バージョンの変更履歴。並列処理、タスク委譲、エージェント制御の変更をバージョン横断で確認できます。',
+  'Agent Teams':
+    'Claude CodeのAgent Teams機能に関する全バージョンの変更履歴。マルチエージェント連携、チーム設定の変更をバージョン横断で確認できます。',
+  Plan: 'Claude CodeのPlan機能に関する全バージョンの変更履歴。計画立案、タスク分解、実行戦略の変更をバージョン横断で確認できます。',
+};
+
+/** ラベル取得(未知エリアはエリア名をそのまま返す) */
+export function getFeatureAreaLabel(area: string): string {
+  return FEATURE_AREA_LABELS[area] ?? area;
+}
+
+/** SEO description 取得(未知エリアはテンプレート生成) */
+export function getFeatureAreaDescription(area: string): string {
+  return (
+    FEATURE_AREA_DESCRIPTIONS[area] ??
+    `Claude Codeの${area}に関する全バージョンの変更履歴`
+  );
+}
+
+export type FeatureAreaItem = { version: string; item: ChangelogItem };
+export type VersionGroup = { version: string; items: ChangelogItem[] };
+
+/** 全 changelog から feature_area 別にアイテムを集約 */
+export function aggregateByFeatureArea(
+  changelogs: { version: string; items: ChangelogItem[] }[],
+): Map<string, FeatureAreaItem[]> {
+  const map = new Map<string, FeatureAreaItem[]>();
+
+  for (const { version, items } of changelogs) {
+    for (const item of items) {
+      const areas = item.feature_areas;
+      if (!areas || areas.length === 0) {
+        continue;
+      }
+
+      for (const area of areas) {
+        const existing = map.get(area);
+        if (existing) {
+          existing.push({ version, item });
+        } else {
+          map.set(area, [{ version, item }]);
+        }
+      }
+    }
+  }
+
+  return map;
+}
+
+/** バージョン降順 → グループ内 importance_score 降順にソート */
+export function groupByVersion(
+  items: FeatureAreaItem[],
+  compareFn: (a: string, b: string) => number,
+): VersionGroup[] {
+  const groupMap = new Map<string, ChangelogItem[]>();
+
+  for (const { version, item } of items) {
+    const existing = groupMap.get(version);
+    if (existing) {
+      existing.push(item);
+    } else {
+      groupMap.set(version, [item]);
+    }
+  }
+
+  // バージョン降順ソート
+  const sorted = [...groupMap.entries()].sort(([a], [b]) => compareFn(a, b));
+
+  // グループ内 importance_score 降順
+  return sorted.map(([version, groupItems]) => ({
+    version,
+    items: groupItems.sort((a, b) => b.importance_score - a.importance_score),
+  }));
+}
+
+/** ビルド時にスラッグの衝突を検出する。衝突があれば Error を throw */
+export function validateSlugUniqueness(areas: string[]): void {
+  const slugToAreas = new Map<string, string[]>();
+
+  for (const area of areas) {
+    const slug = toFeatureAreaSlug(area);
+    const existing = slugToAreas.get(slug);
+    if (existing) {
+      existing.push(area);
+    } else {
+      slugToAreas.set(slug, [area]);
+    }
+  }
+
+  const collisions = [...slugToAreas.entries()].filter(
+    ([, names]) => names.length > 1,
+  );
+  if (collisions.length > 0) {
+    const details = collisions
+      .map(([slug, names]) => `"${slug}" ← [${names.join(', ')}]`)
+      .join('; ');
+    throw new Error(`feature_area スラッグが衝突しています: ${details}`);
+  }
+}

--- a/apps/www/src/lib/json-ld.ts
+++ b/apps/www/src/lib/json-ld.ts
@@ -83,6 +83,37 @@ export function generateFAQJsonLd(items: FAQItem[]): object {
   };
 }
 
+type CollectionPageParams = {
+  siteUrl: string;
+  title: string;
+  description: string;
+  url: string;
+};
+
+export function generateCollectionPageJsonLd(
+  params: CollectionPageParams,
+): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: params.title,
+    description: params.description,
+    url: params.url,
+    inLanguage: 'ja',
+    publisher: {
+      '@type': 'Organization',
+      name: SITE_TITLE,
+      url: params.siteUrl,
+    },
+    about: {
+      '@type': 'SoftwareApplication',
+      name: 'Claude Code',
+      applicationCategory: 'DeveloperApplication',
+      operatingSystem: 'macOS, Linux, Windows',
+    },
+  };
+}
+
 export function generateBreadcrumbJsonLd(items: BreadcrumbItem[]): object {
   return {
     '@context': 'https://schema.org',

--- a/apps/www/src/lib/ogp.tsx
+++ b/apps/www/src/lib/ogp.tsx
@@ -441,6 +441,93 @@ function TwitterChangelogImage({
   );
 }
 
+type FeatureAreaPageOgpProps = {
+  siteTitle: string;
+  areaLabel: string;
+  itemCount: number;
+  versionCount: number;
+};
+
+/**
+ * 機能エリアページ用OGP画像コンポーネント
+ */
+function FeatureAreaPageOgp({
+  siteTitle,
+  areaLabel,
+  itemCount,
+  versionCount,
+}: FeatureAreaPageOgpProps): ReactElement {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        padding: 32,
+        background: `linear-gradient(135deg, ${colors.mainOrange} 0%, ${colors.orangeHover} 100%)`,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          width: '100%',
+          height: '100%',
+          backgroundColor: colors.mainWhite,
+          borderRadius: 24,
+          padding: 48,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 36,
+            fontWeight: 600,
+            color: colors.mainBlack,
+            opacity: 0.6,
+          }}
+        >
+          {siteTitle}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flex: 1,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 80,
+              fontWeight: 600,
+              color: colors.mainBlack,
+            }}
+          >
+            {areaLabel}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 32,
+            fontWeight: 600,
+            color: colors.mainBlack,
+            opacity: 0.7,
+          }}
+        >
+          {`${itemCount}件の変更 / ${versionCount}バージョン`}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /**
  * PNG バイナリから画像レスポンスを生成
  */
@@ -504,6 +591,49 @@ export async function generateVersionPageOgp(
       siteTitle={siteTitle}
       version={version}
       itemCount={itemCount}
+    />,
+    {
+      width: 1200,
+      height: 630,
+      fonts: [
+        {
+          name: 'Noto Sans JP',
+          data: fontData,
+          weight: 600,
+          style: 'normal',
+        },
+      ],
+    },
+  );
+
+  const resvg = new Resvg(svg, {
+    fitTo: {
+      mode: 'width',
+      value: 1200,
+    },
+  });
+  const image = resvg.render();
+
+  return image.asPng();
+}
+
+/**
+ * 機能エリアページ用OGP画像を生成
+ */
+export async function generateFeatureAreaOgp(
+  siteTitle: string,
+  areaLabel: string,
+  itemCount: number,
+  versionCount: number,
+): Promise<Uint8Array> {
+  const fontData = await loadFont();
+
+  const svg = await satori(
+    <FeatureAreaPageOgp
+      siteTitle={siteTitle}
+      areaLabel={areaLabel}
+      itemCount={itemCount}
+      versionCount={versionCount}
     />,
     {
       width: 1200,

--- a/apps/www/src/pages/changelog/[version].astro
+++ b/apps/www/src/pages/changelog/[version].astro
@@ -5,6 +5,10 @@ import PrefixTableOfContents from '../../components/changelog/PrefixTableOfConte
 import Layout from '../../layouts/Layout.astro';
 import { formatChangelogContent } from '../../lib/changelog';
 import {
+  MIN_ITEMS_FOR_PAGE,
+  aggregateByFeatureArea,
+} from '../../lib/feature-area';
+import {
   PREFIX_DEFAULT_STYLE,
   PREFIX_ICONS,
   PREFIX_LABELS,
@@ -34,6 +38,19 @@ export async function getStaticPaths() {
     releaseVersions = new Set();
   }
 
+  // ページが存在する feature_area を算出
+  const areaMap = aggregateByFeatureArea(
+    allChangelogs.map((e) => ({
+      version: e.data.version,
+      items: e.data.items,
+    })),
+  );
+  const linkedAreas = new Set(
+    [...areaMap.entries()]
+      .filter(([, items]) => items.length >= MIN_ITEMS_FOR_PAGE)
+      .map(([area]) => area),
+  );
+
   // バージョン降順ソート
   const sorted = [...allChangelogs].sort((a, b) =>
     semverCompareDesc(a.data.version, b.data.version),
@@ -46,11 +63,13 @@ export async function getStaticPaths() {
       hasGitHubRelease: releaseVersions.has(entry.data.version),
       prevVersion: sorted[i + 1]?.data.version ?? null,
       nextVersion: sorted[i - 1]?.data.version ?? null,
+      linkedAreas,
     },
   }));
 }
 
-const { entry, hasGitHubRelease, prevVersion, nextVersion } = Astro.props;
+const { entry, hasGitHubRelease, prevVersion, nextVersion, linkedAreas } =
+  Astro.props;
 const { version, items, summary } = entry.data;
 
 // メタタグ用 description: summary があれば使用、なければ変更項目数を含めた詳細テキスト
@@ -236,6 +255,7 @@ const totalItemCount = items.length;
                     <ChangelogItemCard
                       item={item}
                       anchorId={`item-${originalIndex}`}
+                      linkedAreas={linkedAreas}
                     />
                   ))}
                 </div>

--- a/apps/www/src/pages/features/[area].astro
+++ b/apps/www/src/pages/features/[area].astro
@@ -1,0 +1,200 @@
+---
+import { getCollection } from 'astro:content';
+import ChangelogItemCard from '../../components/changelog/ChangelogItemCard.astro';
+import Layout from '../../layouts/Layout.astro';
+import {
+  MIN_ITEMS_FOR_PAGE,
+  aggregateByFeatureArea,
+  getFeatureAreaDescription,
+  getFeatureAreaLabel,
+  groupByVersion,
+  toFeatureAreaSlug,
+  validateSlugUniqueness,
+} from '../../lib/feature-area';
+import { semverCompareDesc } from '../../lib/semver';
+
+export async function getStaticPaths() {
+  const allChangelogs = await getCollection('changelog');
+  const data = allChangelogs.map((e) => ({
+    version: e.data.version,
+    items: e.data.items,
+  }));
+  const areaMap = aggregateByFeatureArea(data);
+
+  // 薄いコンテンツ防止: 閾値未満のエリアはページを生成しない
+  const validAreas = [...areaMap.entries()].filter(
+    ([, items]) => items.length >= MIN_ITEMS_FOR_PAGE,
+  );
+
+  // スラッグ衝突チェック(ビルド時安全ネット)
+  validateSlugUniqueness(validAreas.map(([area]) => area));
+
+  return validAreas.map(([area, areaItems]) => ({
+    params: { area: toFeatureAreaSlug(area) },
+    props: { areaName: area, areaItems },
+  }));
+}
+
+const { areaName, areaItems } = Astro.props;
+const slug = toFeatureAreaSlug(areaName);
+const label = getFeatureAreaLabel(areaName);
+const areaDescription = getFeatureAreaDescription(areaName);
+
+const versionGroups = groupByVersion(areaItems, semverCompareDesc);
+const versionCount = versionGroups.length;
+const itemCount = areaItems.length;
+
+// メタ description: 120文字以上保証
+const MIN_DESC_LENGTH = 120;
+const rawDescription = `${areaDescription}(${itemCount}件の変更 / ${versionCount}バージョン)`;
+const description =
+  rawDescription.length < MIN_DESC_LENGTH
+    ? `${rawDescription} Claude Codeの${label}に関する全バージョンのアップデート内容をAIが分析し日本語で解説しています。`
+    : rawDescription;
+
+const siteUrl = import.meta.env.SITE;
+
+const pageTitle = `Claude Code ${label} の変更履歴 - 全バージョンのアップデート内容`;
+
+// 他エリアへのナビゲーション用
+const allChangelogs = await getCollection('changelog');
+const allData = allChangelogs.map((e) => ({
+  version: e.data.version,
+  items: e.data.items,
+}));
+const allAreaMap = aggregateByFeatureArea(allData);
+const linkedAreas = new Set(
+  [...allAreaMap.entries()]
+    .filter(([, items]) => items.length >= MIN_ITEMS_FOR_PAGE)
+    .map(([area]) => area),
+);
+const otherAreas = [...allAreaMap.entries()]
+  .filter(
+    ([area, items]) => area !== areaName && items.length >= MIN_ITEMS_FOR_PAGE,
+  )
+  .sort(([, a], [, b]) => b.length - a.length)
+  .slice(0, 4)
+  .map(([area, items]) => ({
+    slug: toFeatureAreaSlug(area),
+    label: getFeatureAreaLabel(area),
+    itemCount: items.length,
+  }));
+---
+
+<Layout
+  title={pageTitle}
+  description={description}
+  image={`${siteUrl}/features/og/${slug}.png`}
+  jsonLd={{
+    type: 'collection',
+    title: pageTitle,
+    description,
+  }}
+  breadcrumbs={[
+    { name: 'トップ', url: siteUrl },
+    { name: '機能エリア別', url: `${siteUrl}/features` },
+    { name: label, url: `${siteUrl}/features/${slug}` },
+  ]}
+>
+  <div class='min-h-dvh py-12 sm:py-16 px-4'>
+    <div class='max-w-4xl mx-auto'>
+      <nav class='mb-8' aria-label='パンくずリスト'>
+        <a
+          href='/features'
+          data-direction='back'
+          class='text-sm text-[hsl(var(--cc-main-orange))] hover:text-[hsl(var(--cc-orange-hover))] hover:underline inline-flex items-center gap-1 transition-colors'
+        >
+          <svg
+            class='w-4 h-4'
+            fill='none'
+            viewBox='0 0 24 24'
+            stroke='currentColor'
+            stroke-width='2'
+            aria-hidden='true'
+          >
+            <path
+              stroke-linecap='round'
+              stroke-linejoin='round'
+              d='M15 19l-7-7 7-7'></path>
+          </svg>
+          機能エリア一覧に戻る
+        </a>
+      </nav>
+
+      <header class='mb-10'>
+        <h1
+          class='text-3xl sm:text-4xl font-bold text-balance text-[hsl(var(--cc-main-black))] mb-3'
+        >
+          Claude Code {label}
+        </h1>
+        <div
+          class='flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600'
+        >
+          <p>{itemCount}件の変更 / {versionCount}バージョン</p>
+        </div>
+      </header>
+
+      <div data-pagefind-ignore>
+        <div class='space-y-10'>
+          {
+            versionGroups.map((group) => (
+              <section>
+                <div class='sticky top-0 z-10 bg-white/95 backdrop-blur-sm py-3 -mx-4 px-4 mb-4 border-b border-[hsl(var(--cc-gray)/0.3)]'>
+                  <h2 class='flex items-center gap-2 text-lg font-bold text-[hsl(var(--cc-main-black))]'>
+                    <a
+                      href={`/changelog/v${group.version}`}
+                      class='text-[hsl(var(--cc-main-orange))] hover:text-[hsl(var(--cc-orange-hover))] hover:underline transition-colors'
+                    >
+                      v{group.version}
+                    </a>
+                    <span class='text-sm font-normal text-gray-500'>
+                      ({group.items.length}件)
+                    </span>
+                  </h2>
+                </div>
+                <div class='space-y-6'>
+                  {group.items.map((item) => (
+                    <ChangelogItemCard item={item} linkedAreas={linkedAreas} />
+                  ))}
+                </div>
+              </section>
+            ))
+          }
+        </div>
+      </div>
+
+      {
+        otherAreas.length > 0 && (
+          <nav class='mt-16 pt-8 border-t border-[hsl(var(--cc-gray))]'>
+            <h2 class='text-lg font-bold text-[hsl(var(--cc-main-black))] mb-4'>
+              他の機能エリア
+            </h2>
+            <div class='flex flex-wrap gap-3'>
+              {otherAreas.map(
+                ({
+                  slug: otherSlug,
+                  label: otherLabel,
+                  itemCount: otherCount,
+                }) => (
+                  <a
+                    href={`/features/${otherSlug}`}
+                    class='inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[hsl(var(--cc-gray))] hover:border-[hsl(var(--cc-main-orange))] hover:text-[hsl(var(--cc-main-orange))] transition-all'
+                  >
+                    {otherLabel}
+                    <span class='text-xs text-gray-400'>{otherCount}</span>
+                  </a>
+                ),
+              )}
+              <a
+                href='/features'
+                class='inline-flex items-center px-4 py-2 text-sm text-gray-500 hover:text-[hsl(var(--cc-main-orange))] transition-colors'
+              >
+                すべて見る &rarr;
+              </a>
+            </div>
+          </nav>
+        )
+      }
+    </div>
+  </div>
+</Layout>

--- a/apps/www/src/pages/features/index.astro
+++ b/apps/www/src/pages/features/index.astro
@@ -1,0 +1,107 @@
+---
+import { getCollection } from 'astro:content';
+import FeatureAreaCard from '../../components/changelog/FeatureAreaCard.astro';
+import Layout from '../../layouts/Layout.astro';
+import {
+  MIN_ITEMS_FOR_PAGE,
+  aggregateByFeatureArea,
+  getFeatureAreaLabel,
+  toFeatureAreaSlug,
+} from '../../lib/feature-area';
+
+const allChangelogs = await getCollection('changelog');
+const data = allChangelogs.map((e) => ({
+  version: e.data.version,
+  items: e.data.items,
+}));
+const areaMap = aggregateByFeatureArea(data);
+
+// アイテム件数降順でソート、閾値未満を除外
+const areas = [...areaMap.entries()]
+  .filter(([, items]) => items.length >= MIN_ITEMS_FOR_PAGE)
+  .sort(([, a], [, b]) => b.length - a.length)
+  .map(([area, items]) => {
+    const versionSet = new Set(items.map((i) => i.version));
+    return {
+      slug: toFeatureAreaSlug(area),
+      label: getFeatureAreaLabel(area),
+      itemCount: items.length,
+      versionCount: versionSet.size,
+    };
+  });
+
+const siteUrl = import.meta.env.SITE;
+const pageTitle =
+  'Claude Code 機能エリア別 変更履歴 - 機能ごとにアップデートを検索';
+const pageDescription =
+  'Claude Codeの変更履歴を機能エリア別に分類。MCP、Hooks、Settings、IDE/VSCode連携など、特定の機能に関するアップデート内容をバージョンを横断して確認できます。';
+---
+
+<Layout
+  title={pageTitle}
+  description={pageDescription}
+  jsonLd={{
+    type: 'collection',
+    title: pageTitle,
+    description: pageDescription,
+  }}
+  breadcrumbs={[
+    { name: 'トップ', url: siteUrl },
+    { name: '機能エリア別', url: `${siteUrl}/features` },
+  ]}
+>
+  <div class='min-h-dvh py-12 sm:py-16 px-4'>
+    <div class='max-w-6xl mx-auto'>
+      <nav class='mb-8' aria-label='パンくずリスト'>
+        <a
+          href='/'
+          data-direction='back'
+          class='text-sm text-[hsl(var(--cc-main-orange))] hover:text-[hsl(var(--cc-orange-hover))] hover:underline inline-flex items-center gap-1 transition-colors'
+        >
+          <svg
+            class='w-4 h-4'
+            fill='none'
+            viewBox='0 0 24 24'
+            stroke='currentColor'
+            stroke-width='2'
+            aria-hidden='true'
+          >
+            <path
+              stroke-linecap='round'
+              stroke-linejoin='round'
+              d='M15 19l-7-7 7-7'></path>
+          </svg>
+          トップに戻る
+        </a>
+      </nav>
+
+      <header class='mb-12 sm:mb-16 text-center max-w-4xl mx-auto'>
+        <h1
+          class='text-3xl sm:text-4xl font-bold text-balance text-[hsl(var(--cc-main-black))] mb-3'
+        >
+          機能エリア別 変更履歴
+        </h1>
+        <p
+          class='text-base sm:text-lg text-pretty text-gray-600 leading-relaxed'
+        >
+          特定の機能に関する変更履歴をバージョンを横断して確認できます。
+        </p>
+      </header>
+
+      <div
+        class='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6'
+      >
+        {
+          areas.map(({ slug, label, itemCount, versionCount }) => (
+            <FeatureAreaCard
+              slug={slug}
+              label={label}
+              itemCount={itemCount}
+              versionCount={versionCount}
+            />
+          ))
+        }
+      </div>
+    </div>
+  </div>
+</Layout>

--- a/apps/www/src/pages/features/og/[area].png.ts
+++ b/apps/www/src/pages/features/og/[area].png.ts
@@ -1,0 +1,49 @@
+import { getCollection } from 'astro:content';
+import type { APIContext, GetStaticPaths } from 'astro';
+import {
+  MIN_ITEMS_FOR_PAGE,
+  aggregateByFeatureArea,
+  getFeatureAreaLabel,
+  toFeatureAreaSlug,
+} from '@/lib/feature-area';
+import { SITE_TITLE } from '@/lib/constants';
+import { createPngResponse, generateFeatureAreaOgp } from '@/lib/ogp';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const allChangelogs = await getCollection('changelog');
+  const data = allChangelogs.map((e) => ({
+    version: e.data.version,
+    items: e.data.items,
+  }));
+  const areaMap = aggregateByFeatureArea(data);
+
+  return [...areaMap.entries()]
+    .filter(([, items]) => items.length >= MIN_ITEMS_FOR_PAGE)
+    .map(([area, items]) => {
+      const versionSet = new Set(items.map((i) => i.version));
+      return {
+        params: { area: toFeatureAreaSlug(area) },
+        props: {
+          areaLabel: getFeatureAreaLabel(area),
+          itemCount: items.length,
+          versionCount: versionSet.size,
+        },
+      };
+    });
+};
+
+export async function GET({ props }: APIContext) {
+  const { areaLabel, itemCount, versionCount } = props as {
+    areaLabel: string;
+    itemCount: number;
+    versionCount: number;
+  };
+
+  const png = await generateFeatureAreaOgp(
+    SITE_TITLE,
+    areaLabel,
+    itemCount,
+    versionCount,
+  );
+  return createPngResponse(png);
+}

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -3,6 +3,12 @@ import { getCollection } from 'astro:content';
 import VersionCard from '../components/changelog/VersionCard.astro';
 import Layout from '../layouts/Layout.astro';
 import { SITE_TITLE } from '../lib/constants';
+import {
+  MIN_ITEMS_FOR_PAGE,
+  aggregateByFeatureArea,
+  getFeatureAreaLabel,
+  toFeatureAreaSlug,
+} from '../lib/feature-area';
 import { generateFAQJsonLd } from '../lib/json-ld';
 import { semverCompareDesc } from '../lib/semver';
 
@@ -45,6 +51,22 @@ const faqItems = [
   },
 ];
 const faqJsonLd = JSON.stringify(generateFAQJsonLd(faqItems));
+
+// 機能エリアセクション用データ
+const allData = sortedChangelogs.map((e) => ({
+  version: e.data.version,
+  items: e.data.items,
+}));
+const areaMap = aggregateByFeatureArea(allData);
+const topAreas = [...areaMap.entries()]
+  .filter(([, items]) => items.length >= MIN_ITEMS_FOR_PAGE)
+  .sort(([, a], [, b]) => b.length - a.length)
+  .slice(0, 8)
+  .map(([area, items]) => ({
+    slug: toFeatureAreaSlug(area),
+    label: getFeatureAreaLabel(area),
+    itemCount: items.length,
+  }));
 ---
 
 <Layout
@@ -141,6 +163,34 @@ const faqJsonLd = JSON.stringify(generateFAQJsonLd(faqItems));
           </>
         )
       }
+      <section class='mt-16 max-w-3xl mx-auto'>
+        <h2 class='text-2xl font-bold text-[hsl(var(--cc-main-black))] mb-4'>
+          機能エリア別に探す
+        </h2>
+        <p class='text-sm text-gray-600 mb-6'>
+          特定の機能に関する変更履歴をバージョンを横断して確認できます。
+        </p>
+        <div class='flex flex-wrap gap-3'>
+          {
+            topAreas.map(({ slug, label, itemCount }) => (
+              <a
+                href={`/features/${slug}`}
+                class='inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[hsl(var(--cc-gray))] hover:border-[hsl(var(--cc-main-orange))] hover:text-[hsl(var(--cc-main-orange))] transition-all'
+              >
+                {label}
+                <span class='text-xs text-gray-400'>{itemCount}</span>
+              </a>
+            ))
+          }
+          <a
+            href='/features'
+            class='inline-flex items-center px-4 py-2 text-sm text-gray-500 hover:text-[hsl(var(--cc-main-orange))] transition-colors'
+          >
+            すべて見る &rarr;
+          </a>
+        </div>
+      </section>
+
       <section class='mt-16 max-w-3xl mx-auto'>
         <h2 class='text-2xl font-bold text-[hsl(var(--cc-main-black))] mb-8'>
           よくある質問

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist", "contents"],
+  "exclude": ["dist", "contents", "**/__tests__/**"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
機能エリア（MCP, Hooks, Settings 等）を軸にバージョンを横断した
集約ページを生成し、機能軸の検索クエリにランディングページを提供する。

- feature-area.ts: スラッグ変換・ラベル・データ集約・衝突検出
- features/index.astro: 全機能エリアの一覧ページ
- features/[area].astro: 個別機能エリアページ（data-pagefind-ignore）
- features/og/[area].png.ts: OGP 画像生成エンドポイント
- json-ld.ts: CollectionPage 型の JSON-LD 追加
- Layout.astro: collection 型の JSON-LD 対応
- ChangelogItemCard: feature_areas をリンク付きバッジ化
- index.astro: 「機能エリア別に探す」セクション追加
- Footer.astro: 機能エリア別変更履歴リンク追加
- ユニットテスト（15件）追加