### PR TITLE
feat: 不審クローラーブロックルールとEarly Hintsを追加

### DIFF
--- a/terraform/zone/security_bots.tf
+++ b/terraform/zone/security_bots.tf
@@ -7,3 +7,39 @@ resource "cloudflare_bot_management" "main" {
   zone_id    = var.zone_id
   fight_mode = false
 }
+
+# WAF カスタムルール - 不審クローラーブロック
+resource "cloudflare_ruleset" "block_suspicious_crawlers" {
+  zone_id     = var.zone_id
+  name        = "不審クローラーブロック"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+  description = "偽装UAおよびUAなしスキャナーのブロック"
+
+  rules = [
+    {
+      action      = "block"
+      expression  = "(ip.src in {45.86.200.0/24})"
+      description = "F.N.S. Holdings Limited (NL) - 古いUA偽装クローラー"
+      enabled     = true
+    },
+    {
+      action      = "block"
+      expression  = "(ip.src in {185.82.72.0/24})"
+      description = "Pulsant (NL) - 古いUA偽装クローラー"
+      enabled     = true
+    },
+    {
+      action      = "block"
+      expression  = "(ip.src in {74.249.238.26 98.159.37.132})"
+      description = "UAなしスキャナー - 404多数"
+      enabled     = true
+    },
+    {
+      action      = "block"
+      expression  = "(http.request.uri.path contains \".php\" or http.request.uri.path contains \"/wp-admin\" or http.request.uri.path contains \"/wp-login\")"
+      description = "PHPシェル・WordPressスキャナー - 非PHPサイトへのプローブ"
+      enabled     = true
+    }
+  ]
+}

--- a/terraform/zone/settings.tf
+++ b/terraform/zone/settings.tf
@@ -92,3 +92,12 @@ resource "cloudflare_zone_setting" "zero_rtt" {
   setting_id = "0rtt"
   value      = "on"
 }
+
+# Early Hints (HTTP 103) を有効化
+# Cloudflare がオリジンのレスポンスを待つ間に Link ヘッダーを先行送信し、
+# ブラウザが CSS/JS のプリロードを早期に開始できるようにする
+resource "cloudflare_zone_setting" "early_hints" {
+  zone_id    = var.zone_id
+  setting_id = "early_hints"
+  value      = "on"
+}


### PR DESCRIPTION
## 概要

Cloudflare Terraformに2つの設定を追加。

## 変更内容

### WAFカスタムルール（`security_bots.tf`）
- F.N.S. Holdings Limited (45.86.200.0/24) - 古いUA偽装クローラーをブロック
- Pulsant (185.82.72.0/24) - 古いUA偽装クローラーをブロック
- UAなしスキャナー（74.249.238.26, 98.159.37.132）をブロック
- PHPシェル・WordPressスキャナー（`.php`, `/wp-admin`, `/wp-login`へのアクセス）をブロック

### Early Hints（`settings.tf`）
- HTTP 103 Early Hintsを有効化
- オリジンのレスポンス待機中にLinkヘッダーを先行送信し、ブラウザのCSS/JSプリロードを早期開始

🤖 Generated with [Claude Code](https://claude.com/claude-code)