### PR TITLE
fix: トップページの初回表示カード数を30から9に変更

### DIFF
--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+
 import { getCollection } from 'astro:content';
 import VersionCard from '../components/changelog/VersionCard.astro';
 import Layout from '../layouts/Layout.astro';
@@ -38,7 +39,7 @@ const versionData = sortedChangelogs.map((entry) => {
 });
 
 // トップページは最新30件のみ表示、残りは /changelog へ
-const TOP_PAGE_SIZE = 30;
+const TOP_PAGE_SIZE = 9;
 const initialVersions = versionData.slice(0, TOP_PAGE_SIZE);
 const remainingCount = versionData.length - TOP_PAGE_SIZE;
 


### PR DESCRIPTION
## 概要

トップページに初回表示するバージョンカードの件数を 30 件から 9 件に変更。

## 変更内容

- `TOP_PAGE_SIZE` を `30` → `9` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)