### PR TITLE
feat(www): modern-web-guidance に基づき UI/UX を最新 Web 標準へ更新

### DIFF
--- a/apps/www/src/components/MobileMenu.astro
+++ b/apps/www/src/components/MobileMenu.astro
@@ -1,4 +1,5 @@
 ---
+
 type Props = {
   isDocsPage: boolean;
   isReferencePage: boolean;
@@ -49,7 +50,7 @@ const { isDocsPage, isReferencePage } = Astro.props;
 <!-- モバイルメニュードロワー(header基準で絶対配置) -->
 <div
   id='mobile-menu'
-  class='absolute top-full left-0 right-0 sm:hidden hidden border-t border-[hsl(var(--cc-gray))] bg-[hsl(var(--cc-main-white)/0.98)]'
+  class='absolute top-full left-0 right-0 sm:hidden border-t border-[hsl(var(--cc-gray))] bg-[hsl(var(--cc-main-white)/0.98)]'
 >
   <a
     href='/docs'
@@ -67,6 +68,38 @@ const { isDocsPage, isReferencePage } = Astro.props;
   </a>
 </div>
 
+<style>
+  #mobile-menu {
+    display: none;
+    opacity: 0;
+    transform: translateY(-6px);
+    transition:
+      display 0.15s,
+      opacity 0.15s ease-out,
+      transform 0.15s ease-out;
+    transition-behavior: allow-discrete;
+  }
+
+  #mobile-menu.is-open {
+    display: block;
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  @starting-style {
+    #mobile-menu.is-open {
+      opacity: 0;
+      transform: translateY(-6px);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #mobile-menu {
+      transition-duration: 0.01s;
+    }
+  }
+</style>
+
 <script>
   function initMobileMenu() {
     const button = document.getElementById('mobile-menu-btn');
@@ -79,7 +112,7 @@ const { isDocsPage, isReferencePage } = Astro.props;
     }
 
     function toggleMenu(open: boolean) {
-      menu?.classList.toggle('hidden', !open);
+      menu?.classList.toggle('is-open', open);
       button?.setAttribute('aria-expanded', String(open));
       button?.setAttribute(
         'aria-label',

--- a/apps/www/src/components/ScrollProgress.astro
+++ b/apps/www/src/components/ScrollProgress.astro
@@ -4,14 +4,35 @@
 
 <div
   id='scroll-progress'
-  class='fixed top-0 left-0 h-1 w-0 bg-[hsl(var(--cc-main-orange))] z-60 transition-none'
-  role='progressbar'
-  aria-label='ページの読み進め状況'
-  aria-valuenow={0}
-  aria-valuemin={0}
-  aria-valuemax={100}
+  class='fixed top-0 left-0 h-1 w-full bg-[hsl(var(--cc-main-orange))] z-60'
+  aria-hidden='true'
 >
 </div>
+
+<style>
+  #scroll-progress {
+    transform: scaleX(0);
+    transform-origin: left;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    @supports (animation-timeline: scroll()) {
+      @keyframes grow-progress {
+        from {
+          transform: scaleX(0);
+        }
+        to {
+          transform: scaleX(1);
+        }
+      }
+
+      #scroll-progress {
+        animation: grow-progress auto linear;
+        animation-timeline: scroll();
+      }
+    }
+  }
+</style>
 
 <script>
   let controller: AbortController | null = null;
@@ -26,21 +47,26 @@
       return;
     }
 
+    // CSS scroll-driven animation が使える場合はそちらに委ねる
+    if (
+      window.matchMedia('(prefers-reduced-motion: no-preference)').matches &&
+      CSS.supports('animation-timeline', 'scroll()')
+    ) {
+      bar.style.transform = '';
+      return;
+    }
+
     const updateProgress = () => {
-      const scrollTop = window.scrollY;
-      const docHeight =
+      const scrollable =
         document.documentElement.scrollHeight - window.innerHeight;
-      const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
-      bar.style.width = `${progress}%`;
-      bar.setAttribute('aria-valuenow', String(Math.round(progress)));
+      const progress = scrollable > 0 ? window.scrollY / scrollable : 0;
+      bar.style.transform = `scaleX(${progress})`;
     };
 
     window.addEventListener('scroll', updateProgress, {
       signal,
       passive: true,
     });
-
-    // ページ遷移後に初期値をリセット
     updateProgress();
   });
 </script>

--- a/apps/www/src/layouts/Layout.astro
+++ b/apps/www/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+
 import '../styles/global.css';
 import { ClientRouter } from 'astro:transitions';
 import Footer from '../components/Footer.astro';
@@ -266,6 +267,30 @@ if (jsonLd?.type === 'website') {
       }
       initHighlight();
       document.addEventListener('astro:after-swap', initHighlight);
+    </script>
+    <script is:inline>
+      // sibling-index() 非対応ブラウザ(Firefox 等)向けの CSS カスタムプロパティフォールバック
+      function initSiblingIndex() {
+        if (CSS.supports('animation-delay: calc(sibling-index() * 0.1s)')) {
+          return;
+        }
+        for (const cls of [
+          '.changelog-card',
+          '.version-card',
+          '.docs-diff-card',
+        ]) {
+          document.querySelectorAll(cls).forEach((el) => {
+            const parent = el.parentElement;
+            if (!parent) {
+              return;
+            }
+            const idx = Array.prototype.indexOf.call(parent.children, el) + 1;
+            el.style.setProperty('--sibling-index', String(idx));
+          });
+        }
+      }
+      initSiblingIndex();
+      document.addEventListener('astro:after-swap', initSiblingIndex);
     </script>
   </body>
 </html>

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -110,7 +110,7 @@
     }
   }
 
-  /* 変更履歴カードのスタガードアニメーション */
+  /* カードのスタガードアニメーション */
   @keyframes stagger-fade-in {
     from {
       opacity: 0;
@@ -122,68 +122,22 @@
     }
   }
 
-  .changelog-card {
-    animation: stagger-fade-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) backwards;
-  }
-
-  .changelog-card:nth-child(1) { animation-delay: 0.05s; }
-  .changelog-card:nth-child(2) { animation-delay: 0.10s; }
-  .changelog-card:nth-child(3) { animation-delay: 0.15s; }
-  .changelog-card:nth-child(4) { animation-delay: 0.20s; }
-  .changelog-card:nth-child(5) { animation-delay: 0.25s; }
-  .changelog-card:nth-child(6) { animation-delay: 0.30s; }
-  .changelog-card:nth-child(7) { animation-delay: 0.35s; }
-  .changelog-card:nth-child(8) { animation-delay: 0.40s; }
-  .changelog-card:nth-child(9) { animation-delay: 0.45s; }
-  .changelog-card:nth-child(n+10) { animation-delay: 0.50s; }
-
-  @media (prefers-reduced-motion) {
-    .changelog-card {
-      animation: none !important;
-    }
-  }
-
-  /* バージョンカードのスタガードアニメーション */
-  .version-card {
-    animation: stagger-fade-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) backwards;
-  }
-
-  .version-card:nth-child(1) { animation-delay: 0.05s; }
-  .version-card:nth-child(2) { animation-delay: 0.10s; }
-  .version-card:nth-child(3) { animation-delay: 0.15s; }
-  .version-card:nth-child(4) { animation-delay: 0.20s; }
-  .version-card:nth-child(5) { animation-delay: 0.25s; }
-  .version-card:nth-child(6) { animation-delay: 0.30s; }
-  .version-card:nth-child(7) { animation-delay: 0.35s; }
-  .version-card:nth-child(8) { animation-delay: 0.40s; }
-  .version-card:nth-child(9) { animation-delay: 0.45s; }
-  .version-card:nth-child(n+10) { animation-delay: 0.50s; }
-
-  @media (prefers-reduced-motion) {
-    .version-card {
-      animation: none !important;
-    }
-  }
-
-  /* Docs diff カードのスタガードアニメーション */
+  .changelog-card,
+  .version-card,
   .docs-diff-card {
+    --stagger-time: 0.05s;
     animation: stagger-fade-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+    /* sibling-index() 非対応ブラウザ向けに JS が --sibling-index を設定する */
+    animation-delay: calc(var(--sibling-index, 1) * var(--stagger-time));
+    /* sibling-index() 対応ブラウザではこちらが上書きする */
+    animation-delay: calc(sibling-index() * var(--stagger-time));
   }
 
-  .docs-diff-card:nth-child(1) { animation-delay: 0.05s; }
-  .docs-diff-card:nth-child(2) { animation-delay: 0.10s; }
-  .docs-diff-card:nth-child(3) { animation-delay: 0.15s; }
-  .docs-diff-card:nth-child(4) { animation-delay: 0.20s; }
-  .docs-diff-card:nth-child(5) { animation-delay: 0.25s; }
-  .docs-diff-card:nth-child(6) { animation-delay: 0.30s; }
-  .docs-diff-card:nth-child(7) { animation-delay: 0.35s; }
-  .docs-diff-card:nth-child(8) { animation-delay: 0.40s; }
-  .docs-diff-card:nth-child(9) { animation-delay: 0.45s; }
-  .docs-diff-card:nth-child(n+10) { animation-delay: 0.50s; }
-
-  @media (prefers-reduced-motion) {
+  @media (prefers-reduced-motion: reduce) {
+    .changelog-card,
+    .version-card,
     .docs-diff-card {
-      animation: none !important;
+      animation: none;
     }
   }
 }
@@ -252,19 +206,38 @@
 /* モーダル オーバーレイ(body 直下に JS で移動済み)
  * overlay 自身に背景・ぼかしを直接指定する。
  * 子要素に別の backdrop div を作ると fixed 内で描画が限定される。
+ * @starting-style でエントリー/イグジットアニメーションを付与する。
  */
 .search-modal-overlay {
   position: fixed;
   inset: 0;
   z-index: 9999;
   display: none;
+  opacity: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
+  transition:
+    display 0.2s,
+    opacity 0.2s ease-out;
+  transition-behavior: allow-discrete;
 }
 
 .search-modal-overlay.is-open {
   display: block;
+  opacity: 1;
+}
+
+@starting-style {
+  .search-modal-overlay.is-open {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-modal-overlay {
+    transition-duration: 0.01s;
+  }
 }
 
 /* モーダル位置決め */
@@ -293,6 +266,22 @@
   box-shadow:
     0 25px 50px -12px rgba(0, 0, 0, 0.25),
     0 0 0 1px rgba(0, 0, 0, 0.05);
+  transition:
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.25s ease-out;
+}
+
+@starting-style {
+  .search-modal-overlay.is-open .search-modal-content {
+    transform: translateY(-8px) scale(0.97);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-modal-content {
+    transition-duration: 0.01s;
+  }
 }
 
 /* モーダルヘッダー */


### PR DESCRIPTION
## 概要

modern-web-guidance スキルで取得したガイドラインに基づき、`apps/www` の UI/UX 実装を最新の Web 標準に更新。見た目を変えずに、パフォーマンス・コード量・アニメーション品質を改善。

## 変更内容

### `ScrollProgress.astro` — CSS Scroll-Driven Animation
- JS スクロールリスナー(`width` 更新) → CSS `animation-timeline: scroll()` + `scaleX()` transform
- `@supports (animation-timeline: scroll())` + `prefers-reduced-motion: no-preference` でラップ
- Firefox 等の非対応ブラウザ向けに JS フォールバックを維持
- 純粋に装飾的な要素として `aria-hidden="true"` に変更（ガイド準拠）

### `global.css` — `sibling-index()` によるスタガーアニメーション
- `.changelog-card` / `.version-card` / `.docs-diff-card` の `:nth-child()` ブロック（30行超）を `sibling-index()` 1行に置き換え
- 非対応ブラウザ向けに `var(--sibling-index)` フォールバックを先行宣言

### `global.css` — `@starting-style` 検索モーダルアニメーション
- モーダルオーバーレイに `opacity` フェード + `transition-behavior: allow-discrete` を追加
- モーダルコンテンツに `translateY(-8px) scale(0.97)` からのスライドインを追加
- `@starting-style` で `.is-open` 付与時のエントリーを定義

### `MobileMenu.astro` — `@starting-style` ドロワーアニメーション
- `hidden` クラストグル → `is-open` クラストグル + CSS `@starting-style` に移行
- `translateY(-6px)` からのスライドダウンアニメーションを追加

### `Layout.astro` — `sibling-index()` JS フォールバック
- Firefox 向けに `--sibling-index` カスタムプロパティを JS で設定するグローバルスクリプトを追加

## ブラウザ対応方針

| 機能 | 対応ブラウザ | フォールバック |
|---|---|---|
| `animation-timeline: scroll()` | Chrome 115+, Edge 115+, Safari 26+ | JS scroll listener |
| `sibling-index()` | Chrome 138+, Edge 138+, Safari 26.2+ | JS で `--sibling-index` を付与 |
| `@starting-style` | Chrome 117+, Edge 117+, Firefox 129+, Safari 17.5+ | 即時表示(装飾的なため許容) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)