### PR TITLE
類似コードを整理

### DIFF
--- a/apps/notification-worker/src/lib/changelog-message.ts
+++ b/apps/notification-worker/src/lib/changelog-message.ts
@@ -1,0 +1,41 @@
+import { PREFIX_ORDER } from '@claude-code-changelog-viewer/common';
+import type { Analysis } from '@claude-code-changelog-viewer/types';
+
+export type ChangelogMessageItemGroup = {
+  prefix: string;
+  items: Analysis['items'];
+};
+
+export function groupChangelogItemsByPrefix(
+  items: Analysis['items'],
+): ChangelogMessageItemGroup[] {
+  const groupMap = new Map<string, Analysis['items']>();
+  const knownPrefixes = new Set<string>(PREFIX_ORDER);
+  const unknownPrefixes: string[] = [];
+
+  for (const item of items) {
+    const group = groupMap.get(item.prefix) ?? [];
+    if (group.length === 0 && !knownPrefixes.has(item.prefix)) {
+      unknownPrefixes.push(item.prefix);
+    }
+    group.push(item);
+    groupMap.set(item.prefix, group);
+  }
+
+  const groups: ChangelogMessageItemGroup[] = [];
+  for (const prefix of PREFIX_ORDER) {
+    const group = groupMap.get(prefix);
+    if (group) {
+      groups.push({ prefix, items: group });
+    }
+  }
+
+  for (const prefix of unknownPrefixes) {
+    const group = groupMap.get(prefix);
+    if (group) {
+      groups.push({ prefix, items: group });
+    }
+  }
+
+  return groups;
+}

--- a/apps/notification-worker/src/lib/discord.ts
+++ b/apps/notification-worker/src/lib/discord.ts
@@ -2,11 +2,11 @@ import {
   DISCORD_BOT_AVATAR_URL,
   DISCORD_SUPPRESS_EMBEDS,
   type DiscordWebhookPayload,
-  getPrefixSortOrder,
   type Prefix,
   truncateForDiscord,
 } from '@claude-code-changelog-viewer/common';
 import type { Analysis } from '@claude-code-changelog-viewer/types';
+import { groupChangelogItemsByPrefix } from './changelog-message';
 
 const BOT_USERNAME = 'CCログ超訳 Bot';
 
@@ -47,20 +47,7 @@ export function createChangelogMessage(
   content += `${data.summary || 'Claude Codeの新しいバージョンがリリースされました。'}\n`;
 
   if (data.items.length > 0) {
-    // prefix でグループ化
-    const groupMap = new Map<string, typeof data.items>();
-    for (const item of data.items) {
-      const group = groupMap.get(item.prefix) ?? [];
-      group.push(item);
-      groupMap.set(item.prefix, group);
-    }
-
-    // PREFIX_ORDER に従ってソート、未定義 prefix は末尾
-    const sortedEntries = [...groupMap.entries()].sort(
-      ([a], [b]) => getPrefixSortOrder(a) - getPrefixSortOrder(b),
-    );
-
-    for (const [prefix, items] of sortedEntries) {
+    for (const { prefix, items } of groupChangelogItemsByPrefix(data.items)) {
       const label = PREFIX_LABELS[prefix as Prefix] ?? prefix;
       content += `\n## ${label} (${items.length}件)\n`;
       for (const item of items) {

--- a/apps/notification-worker/src/lib/slack.ts
+++ b/apps/notification-worker/src/lib/slack.ts
@@ -1,8 +1,6 @@
-import {
-  getPrefixSortOrder,
-  type Prefix,
-} from '@claude-code-changelog-viewer/common';
+import type { Prefix } from '@claude-code-changelog-viewer/common';
 import type { Analysis } from '@claude-code-changelog-viewer/types';
+import { groupChangelogItemsByPrefix } from './changelog-message';
 
 export type SlackSendResult = {
   ok: boolean;
@@ -67,18 +65,7 @@ export function createSlackChangelogMessage(
   ];
 
   if (data.items.length > 0) {
-    const groupMap = new Map<string, typeof data.items>();
-    for (const item of data.items) {
-      const group = groupMap.get(item.prefix) ?? [];
-      group.push(item);
-      groupMap.set(item.prefix, group);
-    }
-
-    const sortedEntries = [...groupMap.entries()].sort(
-      ([a], [b]) => getPrefixSortOrder(a) - getPrefixSortOrder(b),
-    );
-
-    for (const [prefix, items] of sortedEntries) {
+    for (const { prefix, items } of groupChangelogItemsByPrefix(data.items)) {
       const label = PREFIX_LABELS[prefix as Prefix] ?? prefix;
       let sectionText = `*${label}* (${items.length}件)\n`;
       for (const item of items) {

--- a/apps/www/src/lib/json-ld.ts
+++ b/apps/www/src/lib/json-ld.ts
@@ -14,31 +14,26 @@ export type BreadcrumbItem = {
   url: string;
 };
 
+type WebSiteNodeParams = {
+  siteUrl: string;
+  title: string;
+  description: string;
+};
+
+type WebPageNodeParams = WebSiteNodeParams & {
+  url: string;
+};
+
+type ArticleNodeParams = WebPageNodeParams & {
+  version: string;
+  datePublished?: string;
+};
+
 export type JsonLdGraphParams =
-  | { type: 'website'; siteUrl: string; title: string; description: string }
-  | {
-      type: 'article';
-      siteUrl: string;
-      title: string;
-      description: string;
-      url: string;
-      version: string;
-      datePublished?: string;
-    }
-  | {
-      type: 'collection';
-      siteUrl: string;
-      title: string;
-      description: string;
-      url: string;
-    }
-  | {
-      type: 'page';
-      siteUrl: string;
-      title: string;
-      description: string;
-      url: string;
-    };
+  | ({ type: 'website' } & WebSiteNodeParams)
+  | ({ type: 'article' } & ArticleNodeParams)
+  | ({ type: 'collection' } & WebPageNodeParams)
+  | ({ type: 'page' } & WebPageNodeParams);
 
 // --- 内部ノードビルダー (@context なし・@id 付き) ---
 
@@ -59,11 +54,7 @@ function buildOrganizationNode(siteUrl: string) {
   };
 }
 
-function buildWebSiteNode(params: {
-  siteUrl: string;
-  title: string;
-  description: string;
-}) {
+function buildWebSiteNode(params: WebSiteNodeParams) {
   return {
     '@type': 'WebSite',
     '@id': `${params.siteUrl}/#website`,
@@ -91,12 +82,7 @@ function buildWebSiteNode(params: {
   };
 }
 
-function buildWebPageNode(params: {
-  url: string;
-  title: string;
-  description: string;
-  siteUrl: string;
-}) {
+function buildWebPageNode(params: WebPageNodeParams) {
   return {
     '@type': 'WebPage',
     '@id': `${params.url}#webpage`,
@@ -109,14 +95,7 @@ function buildWebPageNode(params: {
   };
 }
 
-export function buildArticleNode(params: {
-  siteUrl: string;
-  title: string;
-  description: string;
-  url: string;
-  version: string;
-  datePublished?: string;
-}) {
+export function buildArticleNode(params: ArticleNodeParams) {
   return {
     '@type': 'TechArticle',
     '@id': `${params.url}#article`,
@@ -138,12 +117,7 @@ export function buildArticleNode(params: {
   };
 }
 
-function buildCollectionPageNode(params: {
-  url: string;
-  title: string;
-  description: string;
-  siteUrl: string;
-}) {
+function buildCollectionPageNode(params: WebPageNodeParams) {
   return {
     '@type': 'CollectionPage',
     '@id': `${params.url}#webpage`,


### PR DESCRIPTION
## 概要
- Discord/Slack 通知で重複していた changelog item のグルーピング処理を共通化
- JSON-LD の重複していた型リテラルを名前付き型に整理

## 確認
- pnpm run similarity
- pnpm run --filter notification-worker test
- pnpm run ai-check