### PR TITLE
feat(www): 設定リファレンス検索でdescription_jaも検索対象に追加

### DIFF
--- a/apps/www/src/pages/reference/settings/index.astro
+++ b/apps/www/src/pages/reference/settings/index.astro
@@ -186,7 +186,10 @@ const pageDescription =
         <div class='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
           {
             settingsItems.map((entry) => (
-              <div data-key={entry.data.key.toLowerCase()}>
+              <div
+                data-key={entry.data.key.toLowerCase()}
+                data-description={entry.data.description_ja.toLowerCase()}
+              >
                 <SettingCard
                   slug={entry.data.slug}
                   keyName={
@@ -217,7 +220,10 @@ const pageDescription =
         <div class='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
           {
             envItems.map((entry) => (
-              <div data-key={entry.data.key.toLowerCase()}>
+              <div
+                data-key={entry.data.key.toLowerCase()}
+                data-description={entry.data.description_ja.toLowerCase()}
+              >
                 <SettingCard
                   slug={entry.data.slug}
                   keyName={
@@ -302,7 +308,9 @@ const pageDescription =
         let groupVisible = 0;
         for (const card of cards) {
           const key = card.dataset.key ?? '';
-          const visible = q === '' || key.includes(q);
+          const description = card.dataset.description ?? '';
+          const visible =
+            q === '' || key.includes(q) || description.includes(q);
           card.style.display = visible ? '' : 'none';
           if (visible) {
             groupVisible += 1;


### PR DESCRIPTION
設定リファレンスページの検索で、設定名（key）のみが対象だったため
日本語の説明文で検索できなかった問題を修正。

各カードのラッパーにdata-description属性としてdescription_jaを保持し、
検索ロジックでkeyとdescriptionの両方を照合するよう変更。
これにより「自動メモリ」などの日本語説明文での検索が可能になる。

https://claude.ai/code/session_01UyUxiaarD6d5HxKNgqLL4H