### PR TITLE
feat: AIエージェント向けの発見性を強化

### DIFF
--- a/apps/www/public/.well-known/agent-skills/browse-changelog/SKILL.md
+++ b/apps/www/public/.well-known/agent-skills/browse-changelog/SKILL.md
@@ -1,0 +1,27 @@
+# browse-changelog
+
+Browse the Claude Code CHANGELOG with Japanese translations and summaries.
+
+## Description
+
+CCログ超訳 (claude-code-log.com) provides Claude Code's official CHANGELOG with Japanese translations, summaries, and structured navigation by version and feature area.
+
+## Usage
+
+### Browse by version
+Visit `https://claude-code-log.com/changelog/v{version}` to read release notes for a specific version (e.g. `/changelog/v1.0.0`).
+
+### Browse by feature area
+Visit `https://claude-code-log.com/features/` to see changelog entries grouped by feature category.
+
+### Browse documentation diffs
+Visit `https://claude-code-log.com/docs/` to see official documentation change history.
+
+### Machine-readable index
+Fetch `https://claude-code-log.com/llms.txt` for a structured plain-text index of all versions and feature areas, suitable for LLM context.
+
+## Resources
+
+- Home: https://claude-code-log.com/
+- llms.txt: https://claude-code-log.com/llms.txt
+- RSS feed: https://claude-code-log.com/rss.xml

--- a/apps/www/public/.well-known/agent-skills/index.json
+++ b/apps/www/public/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "browse-changelog",
+      "type": "skill-md",
+      "description": "Claude Code の公式 CHANGELOG を日本語訳・要約付きで提供します。バージョン別・機能エリア別に変更履歴を参照できます。",
+      "url": "/.well-known/agent-skills/browse-changelog/SKILL.md",
+      "digest": "sha256:5654d5ad3f29e4d5e72cab508f1d6b41b26b9c94df4b04a541252d263bb161ae"
+    }
+  ]
+}

--- a/apps/www/public/_headers
+++ b/apps/www/public/_headers
@@ -1,4 +1,5 @@
 /*
+  Link: </sitemap-index.xml>; rel="sitemap", </llms.txt>; rel="describedby", </rss.xml>; rel="alternate"; type="application/rss+xml"
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://*.googletagmanager.com https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://static.cloudflareinsights.com; frame-src 'self' https://challenges.cloudflare.com; frame-ancestors 'none'
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Frame-Options: DENY
@@ -21,3 +22,11 @@
 
 /icon.png
   Cache-Control: public, max-age=86400
+
+/.well-known/agent-skills/index.json
+  Content-Type: application/json; charset=utf-8
+  Cache-Control: public, max-age=3600
+
+/.well-known/agent-skills/browse-changelog/SKILL.md
+  Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=3600

--- a/apps/www/src/pages/robots.txt.ts
+++ b/apps/www/src/pages/robots.txt.ts
@@ -5,6 +5,92 @@ User-agent: *
 Allow: /
 Disallow: /api/
 
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ChatGPT Agent
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Gemini-Deep-Research
+Allow: /
+
+User-agent: Google-Gemini-CLI
+Allow: /
+
+User-agent: GoogleAgent-Mariner
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: bedrockbot
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
+User-agent: DuckAssistBot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: DeepSeekBot
+Allow: /
+
+User-agent: MistralAI-User
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Cloudflare-AutoRAG
+Allow: /
+
+User-agent: TavilyBot
+Allow: /
+
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
 Sitemap: ${sitemapURL.href}
 Schemamap: ${schemamapURL.href}
 `;


### PR DESCRIPTION
## 概要

issue #299 の対応として、AIエージェントや AI クローラーに対するサイトの発見性を強化します。

## 変更内容

### `_headers`
- 全ページに RFC 8288 準拠の `Link` レスポンスヘッダーを追加（sitemap / llms.txt / RSS）

### `robots.txt`
- AI クローラー 29 種に明示的な `Allow: /` ルールを追加（OpenAI / Anthropic / Google / Perplexity / Apple / Meta / Amazon / Mistral / DeepSeek 等）
- `Content-Signal` ディレクティブを追加（`ai-train=no, search=yes, ai-input=yes`）

### Agent Skills Discovery（新規）
- `/.well-known/agent-skills/index.json` を追加（RFC v0.2.0 準拠）
- `/.well-known/agent-skills/browse-changelog/SKILL.md` を追加

## 対応しなかった項目

- **Markdown for Agents** — Worker スクリプトの追加が必要なため保留
- **MCP Server Card** — このサイトは MCP サーバーを持たないため非該当
- **DNS-AID / Web Bot Auth / OAuth 系** — インフラ変更が必要 or 非該当

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)