### PR TITLE
fix: 過去バージョン更新時の通知判定を修正

### DIFF
--- a/.github/workflows/changelog-auto-inference.yml
+++ b/.github/workflows/changelog-auto-inference.yml
@@ -65,32 +65,82 @@ jobs:
         run: |
           git add -A
 
-          # チェンジログ(*.md)ファイルの変更を検出
-          CHANGED_FILES=$(git diff --staged --name-only -- 'apps/changelog-fetcher/changelogs/*.md')
+          SUMMARY="apps/changelog-fetcher/metadata/last_fetch_summary.json"
+          if [ ! -f "$SUMMARY" ]; then
+            {
+              echo "has_updates=false"
+              echo "has_notifiable=false"
+            } >> "$GITHUB_OUTPUT"
+            echo "ℹ️ fetch summary がないため更新なし"
+            exit 0
+          fi
 
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+          CURRENT=$(jq -r '.version' claude-version.json)
+          NEW=$(jq -r '.newVersions[]' "$SUMMARY")
+          UPDATED=$(jq -r '.updatedVersions[]' "$SUMMARY")
+          NEW_COUNT=$(jq -r '.newVersions | length' "$SUMMARY")
+          UPDATED_COUNT=$(jq -r '.updatedVersions | length' "$SUMMARY")
+
+          NOTIFIABLE=""
+          while IFS= read -r version; do
+            [ -n "$version" ] || continue
+            clean_version="${version#v}"
+            clean_current="${CURRENT#v}"
+
+            if [ "$clean_version" != "$clean_current" ] && \
+              [ "$(printf '%s\n%s\n' "$clean_current" "$clean_version" | sort -V | tail -n1)" = "$clean_version" ]; then
+              NOTIFIABLE="${NOTIFIABLE} ${version}"
+            fi
+          done <<EOF
+          $NEW
+          EOF
+
+          CHANGED=$(printf '%s\n%s\n' "$NEW" "$UPDATED" | sed '/^$/d' | sort -uV)
+          SALVAGED=""
+          for file in apps/changelog-fetcher/changelogs/*.md; do
+            [ -e "$file" ] || continue
+            version=$(basename "$file" .md)
+            if [ ! -f "apps/changelog-fetcher/analysis/analysis_${version}.json" ] || \
+              [ ! -f "apps/changelog-fetcher/inferred/inferred_${version}.json" ]; then
+              SALVAGED="${SALVAGED} ${version}"
+            fi
+          done
+
+          CHANGED=$(printf '%s\n%s\n' "$CHANGED" "$SALVAGED" | sed '/^$/d' | sort -uV | xargs)
+          NOTIFIABLE=$(printf '%s\n' "$NOTIFIABLE" | tr ' ' '\n' | sed '/^$/d' | sort -uV | xargs)
+
+          if [ -z "$CHANGED" ]; then
+            {
+              echo "has_updates=false"
+              echo "has_notifiable=false"
+            } >> "$GITHUB_OUTPUT"
             echo "ℹ️ チェンジログに更新なし"
             exit 0
-          else
-            echo "has_updates=true" >> "$GITHUB_OUTPUT"
-
-            # ファイル名からバージョン抽出 (apps/changelog-fetcher/changelogs/vX.Y.Z.md → vX.Y.Z)
-            NEW_VERSIONS=$(echo "$CHANGED_FILES" | sed 's|apps/changelog-fetcher/changelogs/||' | sed 's|\.md$||' | tr '\n' ' ' | xargs)
-            echo "new_versions=$NEW_VERSIONS" >> "$GITHUB_OUTPUT"
-
-            echo "✅ チェンジログに更新あり"
-            echo "$CHANGED_FILES"
-            echo ""
-            echo "対象バージョン: $NEW_VERSIONS"
           fi
+
+          {
+            echo "has_updates=true"
+            if [ -n "$NOTIFIABLE" ]; then
+              echo "has_notifiable=true"
+            else
+              echo "has_notifiable=false"
+            fi
+            echo "changed_versions=$CHANGED"
+            echo "notifiable_versions=$NOTIFIABLE"
+            echo "new_count=$NEW_COUNT"
+            echo "updated_count=$UPDATED_COUNT"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "✅ チェンジログに更新あり"
+          echo "解析対象: $CHANGED"
+          echo "通知対象: ${NOTIFIABLE:-なし}"
 
       - name: Analyze changelogs
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
         run: |
-          for version in $NEW_VERSIONS; do
+          for version in $CHANGED_VERSIONS; do
             echo "🔍 Analyzing $version..."
             pnpm run analyze "$version"
           done
@@ -98,9 +148,9 @@ jobs:
       - name: Verify analysis files
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
         run: |
-          for version in $NEW_VERSIONS; do
+          for version in $CHANGED_VERSIONS; do
             if [ ! -f "apps/changelog-fetcher/analysis/analysis_${version}.json" ]; then
               echo "❌ Missing analysis file for $version"
               exit 1
@@ -112,9 +162,9 @@ jobs:
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
         run: |
-          for version in $NEW_VERSIONS; do
+          for version in $CHANGED_VERSIONS; do
             echo "🤖 Inferring benefits for $version..."
             pnpm run infer "$version"
           done
@@ -122,9 +172,9 @@ jobs:
       - name: Verify inferred files
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
         run: |
-          for version in $NEW_VERSIONS; do
+          for version in $CHANGED_VERSIONS; do
             if [ ! -f "apps/changelog-fetcher/inferred/inferred_${version}.json" ]; then
               echo "❌ Missing inferred file for $version"
               exit 1
@@ -139,13 +189,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update version
-        if: steps.detect-updates.outputs.has_updates == 'true'
+        if: steps.detect-updates.outputs.has_notifiable == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          NOTIFIABLE_VERSIONS: ${{ steps.detect-updates.outputs.notifiable_versions }}
         run: |
           chmod +x .github/scripts/update-version.sh
           # shellcheck disable=SC2086
-          .github/scripts/update-version.sh $NEW_VERSIONS
+          .github/scripts/update-version.sh $NOTIFIABLE_VERSIONS
 
       - name: Format code
         if: steps.detect-updates.outputs.has_updates == 'true'
@@ -155,16 +205,20 @@ jobs:
         id: pr-meta
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
+          NOTIFIABLE_VERSIONS: ${{ steps.detect-updates.outputs.notifiable_versions }}
+          NEW_COUNT: ${{ steps.detect-updates.outputs.new_count }}
+          UPDATED_COUNT: ${{ steps.detect-updates.outputs.updated_count }}
         run: |
-          VERSION_COUNT=$(echo "$NEW_VERSIONS" | wc -w | tr -d ' ')
-          FIRST_VERSION=$(echo "$NEW_VERSIONS" | awk '{print $1}')
+          FIRST_VERSION=$(echo "$CHANGED_VERSIONS" | awk '{print $1}')
+          TITLE="chore: CHANGELOG を更新 (新規 ${NEW_COUNT}, 過去更新 ${UPDATED_COUNT})"
 
           {
             echo "branch=chore/changelog-${FIRST_VERSION}"
-            echo "title=chore: CHANGELOGを更新 (${VERSION_COUNT} versions)"
+            echo "title=${TITLE}"
             echo "body<<EOF"
-            echo "対象バージョン: ${NEW_VERSIONS}"
+            echo "解析対象バージョン: ${CHANGED_VERSIONS}"
+            echo "通知対象バージョン: ${NOTIFIABLE_VERSIONS:-なし}"
             echo ""
             echo "自動更新時刻: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
             echo "EOF"
@@ -196,14 +250,14 @@ jobs:
           echo "✓ PR #${PR_NUMBER} をマージしました"
 
       - name: Trigger notification dispatch
-        if: steps.detect-updates.outputs.has_updates == 'true'
+        if: steps.detect-updates.outputs.has_notifiable == 'true'
         env:
           NOTIFICATION_WORKER_URL: ${{ secrets.NOTIFICATION_WORKER_URL }}
           DISPATCH_SECRET: ${{ secrets.DISPATCH_SECRET }}
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          NOTIFIABLE_VERSIONS: ${{ steps.detect-updates.outputs.notifiable_versions }}
         run: |
           echo "📤 通知配信をトリガー..."
-          VERSIONS_JSON=$(echo "$NEW_VERSIONS" | tr ' ' '\n' | jq -R . | jq -s .)
+          VERSIONS_JSON=$(echo "$NOTIFIABLE_VERSIONS" | tr ' ' '\n' | jq -R . | jq -s .)
           curl -f -X POST "${NOTIFICATION_WORKER_URL}/api/dispatch" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${DISPATCH_SECRET}" \
@@ -218,7 +272,7 @@ jobs:
           ISSUE_SUMMARY: |
             CHANGELOGの取得・解析・推論処理に失敗しました。
 
-            **対象バージョン**: ${{ steps.detect-updates.outputs.new_versions }}
+            **対象バージョン**: ${{ steps.detect-updates.outputs.changed_versions }}
           ISSUE_LABELS: automated-failure,workflow:changelog-auto-inference,bug
         with:
           script: |

--- a/apps/changelog-fetcher/src/__tests__/classify-fetched-version.test.ts
+++ b/apps/changelog-fetcher/src/__tests__/classify-fetched-version.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+import { classifyFetchedVersion } from '../domain/changelog/classify-fetched-version';
+
+describe('classifyFetchedVersion', () => {
+  test('ローカルに無いとき new を返す', () => {
+    expect(
+      classifyFetchedVersion({
+        remoteHash: 'remote-a',
+        existingLocalHash: null,
+        existsLocally: false,
+      }),
+    ).toBe('new');
+  });
+
+  test('ローカルに有り、ハッシュが異なるとき updated を返す', () => {
+    expect(
+      classifyFetchedVersion({
+        remoteHash: 'remote-b',
+        existingLocalHash: 'local-a',
+        existsLocally: true,
+      }),
+    ).toBe('updated');
+  });
+
+  test('ローカルに有り、ハッシュが一致するとき unchanged を返す', () => {
+    expect(
+      classifyFetchedVersion({
+        remoteHash: 'same-hash',
+        existingLocalHash: 'same-hash',
+        existsLocally: true,
+      }),
+    ).toBe('unchanged');
+  });
+});

--- a/apps/changelog-fetcher/src/__tests__/merge-analysis-entries.test.ts
+++ b/apps/changelog-fetcher/src/__tests__/merge-analysis-entries.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'vitest';
+import { createAnalyzedChangelogEntry } from '../domain/analysis/analyzed-changelog-entry';
+import { createChangelogAnalysis } from '../domain/analysis/changelog-analysis';
+import { mergeAnalysisEntries } from '../domain/analysis/merge-analysis-entries';
+import type { ChangelogEntry } from '../domain/changelog/changelog-entry';
+import { createChangelogEntry } from '../domain/changelog/changelog-entry';
+import { createChangelogVersion } from '../domain/changelog/changelog-version';
+
+describe('mergeAnalysisEntries', () => {
+  test('既存 analysis が null のとき、全項目が needsSearch に入る', () => {
+    const entries = [entry('- Added alpha'), entry('- Fixed beta')];
+
+    expect(mergeAnalysisEntries(entries, null)).toEqual({
+      reused: [],
+      needsSearch: entries,
+      orderedSlots: [
+        { kind: 'needsSearch', needsSearchIndex: 0 },
+        { kind: 'needsSearch', needsSearchIndex: 1 },
+      ],
+    });
+  });
+
+  test('全項目が既存と一致するとき、全項目が reused に入り needsSearch が空になる', () => {
+    const entries = [entry('- Added alpha'), entry('- Fixed beta')];
+    const existingAnalysis = analysis([
+      analyzed('- Added alpha', 'docs/alpha.md'),
+      analyzed('- Fixed beta', 'docs/beta.md'),
+    ]);
+
+    const result = mergeAnalysisEntries(entries, existingAnalysis);
+
+    expect(result.reused).toEqual(existingAnalysis.items);
+    expect(result.needsSearch).toEqual([]);
+    expect(result.orderedSlots).toEqual([
+      { kind: 'reused', reusedIndex: 0 },
+      { kind: 'reused', reusedIndex: 1 },
+    ]);
+  });
+
+  test('末尾に1項目追加された場合、新規1件のみ needsSearch に入り既存項目は relatedDocs を保持する', () => {
+    const entries = [
+      entry('- Added alpha'),
+      entry('- Fixed beta'),
+      entry('- Updated gamma'),
+    ];
+    const existingAnalysis = analysis([
+      analyzed('- Added alpha', 'docs/alpha.md'),
+      analyzed('- Fixed beta', 'docs/beta.md'),
+    ]);
+
+    const result = mergeAnalysisEntries(entries, existingAnalysis);
+
+    expect(result.reused.map((item) => item.relatedDocs)).toEqual([
+      [{ file: 'docs/alpha.md', snippets: ['alpha'], hitCount: 1 }],
+      [{ file: 'docs/beta.md', snippets: ['beta'], hitCount: 1 }],
+    ]);
+    expect(result.needsSearch).toEqual([entries[2]]);
+    expect(result.orderedSlots).toEqual([
+      { kind: 'reused', reusedIndex: 0 },
+      { kind: 'reused', reusedIndex: 1 },
+      { kind: 'needsSearch', needsSearchIndex: 0 },
+    ]);
+  });
+
+  test('末尾から1項目削除された場合、出力スロット数が現項目数に一致し削除項目を含まない', () => {
+    const entries = [entry('- Added alpha')];
+    const result = mergeAnalysisEntries(
+      entries,
+      analysis([
+        analyzed('- Added alpha', 'docs/alpha.md'),
+        analyzed('- Removed old tail', 'docs/old.md'),
+      ]),
+    );
+
+    expect(result.orderedSlots).toHaveLength(entries.length);
+    expect(result.reused.map((item) => item.content)).toEqual([
+      '- Added alpha',
+    ]);
+    expect(result.needsSearch).toEqual([]);
+  });
+
+  test('同じ content が複数現れる重複ケースで index 位置に従って流用と再検索を振り分ける', () => {
+    const duplicated = '- Added duplicated';
+    const entries = [
+      entry(duplicated),
+      entry('- Fixed inserted'),
+      entry(duplicated),
+    ];
+    const result = mergeAnalysisEntries(
+      entries,
+      analysis([
+        analyzed(duplicated, 'docs/first.md'),
+        analyzed(duplicated, 'docs/second.md'),
+      ]),
+    );
+
+    expect(result.reused.map((item) => item.relatedDocs[0]?.file)).toEqual([
+      'docs/first.md',
+    ]);
+    expect(result.needsSearch.map((item) => item.content)).toEqual([
+      '- Fixed inserted',
+      duplicated,
+    ]);
+    expect(result.orderedSlots).toEqual([
+      { kind: 'reused', reusedIndex: 0 },
+      { kind: 'needsSearch', needsSearchIndex: 0 },
+      { kind: 'needsSearch', needsSearchIndex: 1 },
+    ]);
+  });
+});
+
+function entry(value: string): ChangelogEntry {
+  return createChangelogEntry(value);
+}
+
+function analyzed(content: string, file: string) {
+  const entry = createChangelogEntry(content);
+
+  return createAnalyzedChangelogEntry({
+    content: entry.content,
+    prefix: entry.prefix,
+    relatedDocs: [
+      {
+        file,
+        snippets: [file.replace(/^docs\//, '').replace(/\.md$/, '')],
+        hitCount: 1,
+      },
+    ],
+  });
+}
+
+function analysis(items: ReturnType<typeof analyzed>[]) {
+  return createChangelogAnalysis({
+    version: createChangelogVersion('v1.0.0'),
+    items,
+  });
+}

--- a/apps/changelog-fetcher/src/__tests__/transfer-existing-inference.test.ts
+++ b/apps/changelog-fetcher/src/__tests__/transfer-existing-inference.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'vitest';
+import { createAnalyzedChangelogEntry } from '../domain/analysis/analyzed-changelog-entry';
+import { createChangelogAnalysis } from '../domain/analysis/changelog-analysis';
+import { transferExistingInference } from '../domain/analysis/transfer-existing-inference';
+import { createChangelogEntry } from '../domain/changelog/changelog-entry';
+import { createChangelogVersion } from '../domain/changelog/changelog-version';
+import { createInferenceResult } from '../domain/inference/inference-result';
+import { findMissingInferenceItems } from '../usecase/inference-batch';
+
+describe('transferExistingInference', () => {
+  test('既存 inferred が null のとき、入力 analysis をそのまま返す', () => {
+    const currentAnalysis = analysis([analyzed('- Added alpha')]);
+
+    expect(transferExistingInference(currentAnalysis, null)).toBe(
+      currentAnalysis,
+    );
+  });
+
+  test('全項目が既存と一致するとき、推論情報を転写し missing が空になる', () => {
+    const currentAnalysis = analysis([
+      analyzed('- Added alpha'),
+      analyzed('- Fixed beta'),
+    ]);
+    const result = transferExistingInference(
+      currentAnalysis,
+      analysis([
+        inferred('- Added alpha', 'アルファを追加しました'),
+        inferred('- Fixed beta', 'ベータを修正しました'),
+      ]),
+    );
+
+    expect(result.items.map((item) => item.contentJa)).toEqual([
+      'アルファを追加しました',
+      'ベータを修正しました',
+    ]);
+    expect(result.items.map((item) => item.inference?.benefit)).toEqual([
+      '利用者はアルファ機能をすぐ使えるようになります',
+      '利用者はベータ不具合の影響を避けられます',
+    ]);
+    expect(findMissingInferenceItems(result)).toEqual([]);
+  });
+
+  test('末尾に1項目追加された場合、追加項目以外を転写し missing は追加項目1件のみになる', () => {
+    const currentAnalysis = analysis([
+      analyzed('- Added alpha'),
+      analyzed('- Fixed beta'),
+    ]);
+    const result = transferExistingInference(
+      currentAnalysis,
+      analysis([inferred('- Added alpha', 'アルファを追加しました')]),
+    );
+
+    expect(result.items[0]?.contentJa).toBe('アルファを追加しました');
+    expect(result.items[1]?.contentJa).toBeUndefined();
+    expect(
+      findMissingInferenceItems(result).map((item) => item.originalIndex),
+    ).toEqual([1]);
+  });
+
+  test('末尾から1項目削除された場合、転写後の項目数が現 analysis に一致する', () => {
+    const currentAnalysis = analysis([analyzed('- Added alpha')]);
+    const result = transferExistingInference(
+      currentAnalysis,
+      analysis([
+        inferred('- Added alpha', 'アルファを追加しました'),
+        inferred('- Removed tail', '末尾を削除しました'),
+      ]),
+    );
+
+    expect(result.items).toHaveLength(currentAnalysis.items.length);
+    expect(result.items.map((item) => item.content)).toEqual(['- Added alpha']);
+  });
+});
+
+function analyzed(content: string) {
+  const entry = createChangelogEntry(content);
+
+  return createAnalyzedChangelogEntry({
+    content: entry.content,
+    prefix: entry.prefix,
+    relatedDocs: [
+      { file: 'docs/example.md', snippets: ['example'], hitCount: 1 },
+    ],
+  });
+}
+
+function inferred(content: string, contentJa: string) {
+  return createAnalyzedChangelogEntry({
+    ...analyzed(content),
+    contentJa,
+    featureAreas: ['core'],
+    inference: createInferenceResult({
+      before: '利用者は変更前の挙動に合わせて手作業で対応していました',
+      after: '利用者は変更後の挙動をそのまま利用できます',
+      benefit: content.includes('Fixed')
+        ? '利用者はベータ不具合の影響を避けられます'
+        : '利用者はアルファ機能をすぐ使えるようになります',
+    }),
+  });
+}
+
+function analysis(items: ReturnType<typeof analyzed>[]) {
+  return createChangelogAnalysis({
+    version: createChangelogVersion('v1.0.0'),
+    items,
+  });
+}

--- a/apps/changelog-fetcher/src/domain/analysis/merge-analysis-entries.ts
+++ b/apps/changelog-fetcher/src/domain/analysis/merge-analysis-entries.ts
@@ -1,0 +1,49 @@
+import type { ChangelogEntry } from '../changelog/changelog-entry';
+import type { AnalyzedChangelogEntry } from './analyzed-changelog-entry';
+import type { ChangelogAnalysis } from './changelog-analysis';
+
+export type AnalysisMergeSlot =
+  | {
+      kind: 'reused';
+      reusedIndex: number;
+    }
+  | {
+      kind: 'needsSearch';
+      needsSearchIndex: number;
+    };
+
+export type AnalysisMergeResult = {
+  reused: AnalyzedChangelogEntry[];
+  needsSearch: ChangelogEntry[];
+  orderedSlots: AnalysisMergeSlot[];
+};
+
+export function mergeAnalysisEntries(
+  currentEntries: ChangelogEntry[],
+  existingAnalysis: ChangelogAnalysis | null,
+): AnalysisMergeResult {
+  const reused: AnalyzedChangelogEntry[] = [];
+  const needsSearch: ChangelogEntry[] = [];
+  const orderedSlots: AnalysisMergeSlot[] = [];
+
+  for (const [index, entry] of currentEntries.entries()) {
+    const existingEntry = existingAnalysis?.items[index];
+
+    if (
+      existingEntry !== undefined &&
+      existingEntry.content === entry.content
+    ) {
+      orderedSlots.push({ kind: 'reused', reusedIndex: reused.length });
+      reused.push(existingEntry);
+      continue;
+    }
+
+    orderedSlots.push({
+      kind: 'needsSearch',
+      needsSearchIndex: needsSearch.length,
+    });
+    needsSearch.push(entry);
+  }
+
+  return { reused, needsSearch, orderedSlots };
+}

--- a/apps/changelog-fetcher/src/domain/analysis/transfer-existing-inference.ts
+++ b/apps/changelog-fetcher/src/domain/analysis/transfer-existing-inference.ts
@@ -1,0 +1,42 @@
+import { createAnalyzedChangelogEntry } from './analyzed-changelog-entry';
+import {
+  type ChangelogAnalysis,
+  createChangelogAnalysis,
+} from './changelog-analysis';
+
+export function transferExistingInference(
+  currentAnalysis: ChangelogAnalysis,
+  existingInferred: ChangelogAnalysis | null,
+): ChangelogAnalysis {
+  if (existingInferred === null) {
+    return currentAnalysis;
+  }
+
+  return createChangelogAnalysis({
+    version: currentAnalysis.version,
+    ...((currentAnalysis.summary ?? existingInferred.summary) !== undefined
+      ? { summary: currentAnalysis.summary ?? existingInferred.summary }
+      : {}),
+    items: currentAnalysis.items.map((entry, index) => {
+      const existingEntry = existingInferred.items[index];
+
+      if (
+        existingEntry === undefined ||
+        existingEntry.content !== entry.content
+      ) {
+        return entry;
+      }
+
+      return createAnalyzedChangelogEntry({
+        ...entry,
+        ...(existingEntry.contentJa !== undefined
+          ? { contentJa: existingEntry.contentJa }
+          : {}),
+        featureAreas: existingEntry.featureAreas,
+        ...(existingEntry.inference !== undefined
+          ? { inference: existingEntry.inference }
+          : {}),
+      });
+    }),
+  });
+}

--- a/apps/changelog-fetcher/src/domain/changelog/classify-fetched-version.ts
+++ b/apps/changelog-fetcher/src/domain/changelog/classify-fetched-version.ts
@@ -1,0 +1,20 @@
+export type FetchedVersionClassification = 'new' | 'updated' | 'unchanged';
+
+export function classifyFetchedVersion(input: {
+  remoteHash: string;
+  existingLocalHash: string | null;
+  existsLocally: boolean;
+}): FetchedVersionClassification {
+  if (!input.existsLocally) {
+    return 'new';
+  }
+
+  if (
+    input.existingLocalHash === null ||
+    input.remoteHash !== input.existingLocalHash
+  ) {
+    return 'updated';
+  }
+
+  return 'unchanged';
+}

--- a/apps/changelog-fetcher/src/infer-benefits.ts
+++ b/apps/changelog-fetcher/src/infer-benefits.ts
@@ -4,6 +4,7 @@ import { getLogger, toError } from '@claude-code-changelog-viewer/common';
 import { AnalysisSchema } from '@claude-code-changelog-viewer/types';
 import { inferBenefits, type InferencePort } from './usecase/infer-benefits';
 import { GeminiInferenceClient } from './infrastructure/ai/gemini-inference-client';
+import { createInferredFileStore } from './infrastructure/filesystem/changelog-file-store';
 import {
   toAnalysisJson,
   toChangelogAnalysis,
@@ -54,7 +55,13 @@ async function main(): Promise<void> {
       );
 
   const inferred = toAnalysisJson(
-    await inferBenefits({ version, analysis, skipAI, inference }),
+    await inferBenefits({
+      version,
+      analysis,
+      skipAI,
+      inference,
+      store: createInferredFileStore(process.cwd()),
+    }),
   );
 
   mkdirSync(inferredDir, { recursive: true });

--- a/apps/changelog-fetcher/src/infrastructure/filesystem/changelog-file-store.ts
+++ b/apps/changelog-fetcher/src/infrastructure/filesystem/changelog-file-store.ts
@@ -1,11 +1,14 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { AnalysisSchema } from '@claude-code-changelog-viewer/types';
 import type {
   ChangelogMetadata,
   ChangelogStorePort,
+  FetchChangelogSummary,
 } from '../../usecase/fetch-changelog';
 import type { AnalysisStorePort } from '../../usecase/analyze-changelog';
+import type { InferredStorePort } from '../../usecase/infer-benefits';
 import type { ChangelogAnalysis } from '../../domain/analysis/changelog-analysis';
 import type { ChangelogDiffEvent } from '../../domain/changelog/changelog-diff-event';
 import type { ChangelogRelease } from '../../domain/changelog/changelog-release';
@@ -16,7 +19,10 @@ import {
 } from '../../domain/changelog/changelog-version';
 import type { ChangelogDiffEventType } from '../../domain/changelog/changelog-diff-event';
 import { parseChangelogReleases } from '../docs/changelog-markdown-parser';
-import { toAnalysisJson } from '../serializers/analysis-serializer';
+import {
+  toAnalysisJson,
+  toChangelogAnalysis,
+} from '../serializers/analysis-serializer';
 
 export type ChangelogDiffJson = {
   events: DiffEventJson[];
@@ -32,6 +38,11 @@ export type DiffEventJson = {
 
 export function createAnalysisFileStore(appDir: string): AnalysisStorePort {
   return {
+    async load(version: string): Promise<ChangelogAnalysis | null> {
+      return loadAnalysisFile(
+        join(appDir, 'analysis', `analysis_${version}.json`),
+      );
+    },
     async save(analysis: ChangelogAnalysis, version: string): Promise<void> {
       const output = toAnalysisJson(analysis);
       const outputPath = join(appDir, 'analysis', `analysis_${version}.json`);
@@ -40,14 +51,26 @@ export function createAnalysisFileStore(appDir: string): AnalysisStorePort {
   };
 }
 
+export function createInferredFileStore(appDir: string): InferredStorePort {
+  return {
+    async load(version: string): Promise<ChangelogAnalysis | null> {
+      return loadAnalysisFile(
+        join(appDir, 'inferred', `inferred_${version}.json`),
+      );
+    },
+  };
+}
+
 export class ChangelogFileStore implements ChangelogStorePort {
   #outputDir: string;
   #metadataFile: string;
+  #summaryFile: string;
   #diffFile: string;
 
   constructor(appDir: string) {
     this.#outputDir = join(appDir, 'changelogs');
     this.#metadataFile = join(appDir, 'metadata', 'last_fetch.json');
+    this.#summaryFile = join(appDir, 'metadata', 'last_fetch_summary.json');
     this.#diffFile = join(appDir, 'diff', 'changelog_diff.json');
   }
 
@@ -66,6 +89,19 @@ export class ChangelogFileStore implements ChangelogStorePort {
     await writeFile(
       this.#metadataFile,
       `${JSON.stringify(metadata, null, 2)}\n`,
+      'utf-8',
+    );
+  }
+
+  async deleteFetchSummary(): Promise<void> {
+    await rm(this.#summaryFile, { force: true });
+  }
+
+  async saveFetchSummary(summary: FetchChangelogSummary): Promise<void> {
+    await mkdir(dirname(this.#summaryFile), { recursive: true });
+    await writeFile(
+      this.#summaryFile,
+      `${JSON.stringify(summary, null, 2)}\n`,
       'utf-8',
     );
   }
@@ -144,4 +180,16 @@ function toDiffEventJson(event: ChangelogDiffEvent): DiffEventJson {
 
 function toVersionFilename(version: ChangelogVersion): string {
   return `${version}.md`;
+}
+
+async function loadAnalysisFile(
+  filePath: string,
+): Promise<ChangelogAnalysis | null> {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  return toChangelogAnalysis(
+    AnalysisSchema.parse(JSON.parse(await readFile(filePath, 'utf-8'))),
+  );
 }

--- a/apps/changelog-fetcher/src/parse-changelog.ts
+++ b/apps/changelog-fetcher/src/parse-changelog.ts
@@ -12,10 +12,14 @@ const log = getLogger({ name: 'changelog-fetcher' });
 
 async function main(): Promise<void> {
   const appDir = join(__dirname, '..');
+  const store = new ChangelogFileStore(appDir);
+
+  await store.deleteFetchSummary();
   const result = await fetchChangelog({
     source: new ClaudeCodeChangelogClient(),
-    store: new ChangelogFileStore(appDir),
+    store,
   });
+  await store.saveFetchSummary(result.summary);
 
   if (result.newCount === 0 && result.updatedCount === 0) {
     log.msg('APLG0008', { params: ['CHANGELOG'] });

--- a/apps/changelog-fetcher/src/usecase/analyze-changelog.ts
+++ b/apps/changelog-fetcher/src/usecase/analyze-changelog.ts
@@ -4,6 +4,7 @@ import {
   createChangelogAnalysis,
   type ChangelogAnalysis,
 } from '../domain/analysis/changelog-analysis';
+import { mergeAnalysisEntries } from '../domain/analysis/merge-analysis-entries';
 import type { RelatedDoc } from '../domain/analysis/related-doc';
 import type { ChangelogEntry } from '../domain/changelog/changelog-entry';
 import { createChangelogVersion } from '../domain/changelog/changelog-version';
@@ -15,6 +16,7 @@ export type DocsSearchPort = {
 };
 
 export type AnalysisStorePort = {
+  load: (version: string) => Promise<ChangelogAnalysis | null>;
   save: (analysis: ChangelogAnalysis, version: string) => Promise<void>;
 };
 
@@ -29,10 +31,19 @@ export async function analyzeChangelog(input: {
 
   log.msg('APLG0010', { params: [`${entries.length} 件の項目`] });
 
-  const items = await Promise.all(
-    entries.map(async (entry, index) => {
+  const merged = mergeAnalysisEntries(
+    entries,
+    await input.store.load(input.version),
+  );
+  log.info('既存 analysis の差分マージ', {
+    reused: merged.reused.length,
+    needsSearch: merged.needsSearch.length,
+  });
+
+  const searched = await Promise.all(
+    merged.needsSearch.map(async (entry, index) => {
       log.info(
-        `[${index + 1}/${entries.length}] ${entry.content.slice(0, 60)}...`,
+        `[${index + 1}/${merged.needsSearch.length}] ${entry.content.slice(0, 60)}...`,
       );
 
       const relatedDocs = await input.docsSearch.findRelatedDocs(entry);
@@ -45,6 +56,18 @@ export async function analyzeChangelog(input: {
     }),
   );
 
+  const items = merged.orderedSlots.map((slot) => {
+    const item =
+      slot.kind === 'reused'
+        ? merged.reused[slot.reusedIndex]
+        : searched[slot.needsSearchIndex];
+
+    if (item === undefined) {
+      throw new Error('analysis 差分マージのスロット復元に失敗しました');
+    }
+
+    return item;
+  });
   const analysis = createChangelogAnalysis({ version, items });
   await input.store.save(analysis, input.version);
   return analysis;

--- a/apps/changelog-fetcher/src/usecase/fetch-changelog.ts
+++ b/apps/changelog-fetcher/src/usecase/fetch-changelog.ts
@@ -7,6 +7,7 @@ import {
   isDuplicateDiffEvent,
   type ChangelogDiffEvent,
 } from '../domain/changelog/changelog-diff-event';
+import { classifyFetchedVersion } from '../domain/changelog/classify-fetched-version';
 import type { ChangelogRelease } from '../domain/changelog/changelog-release';
 import {
   createChangelogVersion,
@@ -36,6 +37,14 @@ export type ChangelogStorePort = {
 export type FetchChangelogResult = {
   newCount: number;
   updatedCount: number;
+  summary: FetchChangelogSummary;
+};
+
+export type FetchChangelogSummary = {
+  fetchedAt: string;
+  newVersions: string[];
+  updatedVersions: string[];
+  removedVersions: string[];
 };
 
 export async function fetchChangelog(input: {
@@ -53,6 +62,9 @@ export async function fetchChangelog(input: {
 
   let newCount = 0;
   let updatedCount = 0;
+  const newVersions: string[] = [];
+  const updatedVersions: string[] = [];
+  const removedVersions: string[] = [];
   const newMetadata: Record<string, string> = {};
   const remoteVersionKeys = new Set<string>();
 
@@ -63,10 +75,15 @@ export async function fetchChangelog(input: {
     const contentHash = createHash('sha256')
       .update(release.content, 'utf-8')
       .digest('hex');
-    const existingHash = existingMetadata.versions[versionKey] ?? '';
+    const existingHash = existingMetadata.versions[versionKey] ?? null;
     const localRelease = await input.store.loadRelease(release.version);
+    const classification = classifyFetchedVersion({
+      remoteHash: contentHash,
+      existingLocalHash: existingHash,
+      existsLocally: localRelease !== null,
+    });
 
-    if (contentHash !== existingHash && localRelease) {
+    if (classification === 'updated' && localRelease) {
       const diff = computeChangelogEntryDiff(
         localRelease.entries,
         release.entries,
@@ -87,7 +104,7 @@ export async function fetchChangelog(input: {
       }
     }
 
-    if (contentHash === existingHash && localRelease) {
+    if (classification === 'unchanged') {
       log.debug(`${versionKey}: 変更なし`);
       newMetadata[versionKey] = contentHash;
       continue;
@@ -95,12 +112,14 @@ export async function fetchChangelog(input: {
 
     await input.store.saveRelease(release);
 
-    if (existingHash) {
+    if (classification === 'updated') {
       log.info(`${versionKey}: 更新あり`);
       updatedCount += 1;
+      updatedVersions.push(versionKey);
     } else {
       log.info(`${versionKey}: 新規`);
       newCount += 1;
+      newVersions.push(versionKey);
     }
 
     newMetadata[versionKey] = contentHash;
@@ -115,6 +134,7 @@ export async function fetchChangelog(input: {
       detectedAt,
       version: createChangelogVersion(metadataVersionKey),
     });
+    removedVersions.push(metadataVersionKey);
 
     if (!isDuplicateDiffEvent(diffEvents, candidate)) {
       diffEvents.push(candidate);
@@ -130,5 +150,14 @@ export async function fetchChangelog(input: {
 
   log.msg('APLG0002', { params: ['CHANGELOG の取得'] });
 
-  return { newCount, updatedCount };
+  return {
+    newCount,
+    updatedCount,
+    summary: {
+      fetchedAt: detectedAt.toISOString(),
+      newVersions,
+      updatedVersions,
+      removedVersions,
+    },
+  };
 }

--- a/apps/changelog-fetcher/src/usecase/infer-benefits.ts
+++ b/apps/changelog-fetcher/src/usecase/infer-benefits.ts
@@ -1,6 +1,7 @@
 import { getLogger } from '@claude-code-changelog-viewer/common';
 import pRetry, { AbortError } from 'p-retry';
 import type { ChangelogAnalysis } from '../domain/analysis/changelog-analysis';
+import { transferExistingInference } from '../domain/analysis/transfer-existing-inference';
 import {
   applyInferenceBatch,
   findMissingInferenceItems,
@@ -17,11 +18,16 @@ export type InferencePort = {
   }) => Promise<InferenceBatch>;
 };
 
+export type InferredStorePort = {
+  load: (version: string) => Promise<ChangelogAnalysis | null>;
+};
+
 export async function inferBenefits(input: {
   version: string;
   analysis: ChangelogAnalysis;
   skipAI: boolean;
   inference: InferencePort;
+  store: InferredStorePort;
 }): Promise<ChangelogAnalysis> {
   if (input.skipAI) {
     log.info('AI推論をスキップ (コピーモード)', {
@@ -35,16 +41,24 @@ export async function inferBenefits(input: {
     attrs: { totalItems: input.analysis.items.length },
   });
 
-  let analysis = applyInferenceBatch(
+  let analysis = transferExistingInference(
     input.analysis,
-    await input.inference.infer({
-      version: input.version,
-      items: input.analysis.items.map((entry, originalIndex) => ({
-        entry,
-        originalIndex,
-      })),
-    }),
+    await input.store.load(input.version),
   );
+  const missingBeforeInitial = findMissingInferenceItems(analysis);
+
+  if (missingBeforeInitial.length === 0) {
+    log.info('既存 inferred を全項目に流用したため AI推論をスキップ');
+    return analysis;
+  }
+
+  analysis = applyInferenceBatch(analysis, {
+    ...(await input.inference.infer({
+      version: input.version,
+      items: missingBeforeInitial,
+    })),
+    ...(analysis.summary !== undefined ? { summary: analysis.summary } : {}),
+  });
   log.msg('APLG0002', { params: ['バージョンサマリー生成'] });
 
   const missingAfterInitial = findMissingInferenceItems(analysis);
@@ -64,13 +78,15 @@ export async function inferBenefits(input: {
       }
 
       try {
-        analysis = applyInferenceBatch(
-          analysis,
-          await input.inference.infer({
+        analysis = applyInferenceBatch(analysis, {
+          ...(await input.inference.infer({
             version: input.version,
             items: missing,
-          }),
-        );
+          })),
+          ...(analysis.summary !== undefined
+            ? { summary: analysis.summary }
+            : {}),
+        });
       } catch (error) {
         throw new AbortError(
           error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## 概要
- fetcher が `last_fetch_summary.json` に新規・更新・削除バージョンの事実だけを書き出すようにしました
- analysis / inferred を index + content 一致で差分マージし、既存項目の docs search / Gemini 推論を流用するようにしました
- workflow の通知・version 更新対象を summary + `claude-version.json` の semver 比較で決めるようにしました

## 検証
- `pnpm run --filter changelog-fetcher test`
- `pnpm run ai-check`
- `actionlint .github/workflows/changelog-auto-inference.yml`
- `ghalint run --config .github/ghalint.yaml`
- `pinact run --check`
- 検証手順 A〜D をローカル入力で再現確認

Closes #334