### PR TITLE
fix: 過去バージョン更新時の差分処理を修正

### DIFF
--- a/.github/workflows/changelog-auto-inference.yml
+++ b/.github/workflows/changelog-auto-inference.yml
@@ -65,32 +65,82 @@ jobs:
         run: |
           git add -A
 
-          # チェンジログ(*.md)ファイルの変更を検出
-          CHANGED_FILES=$(git diff --staged --name-only -- 'apps/changelog-fetcher/changelogs/*.md')
+          SUMMARY="apps/changelog-fetcher/metadata/last_fetch_summary.json"
+          if [ ! -f "$SUMMARY" ]; then
+            {
+              echo "has_updates=false"
+              echo "has_notifiable=false"
+            } >> "$GITHUB_OUTPUT"
+            echo "ℹ️ fetch summary がないため更新なし"
+            exit 0
+          fi
 
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+          CURRENT=$(jq -r '.version' claude-version.json)
+          NEW=$(jq -r '.newVersions[]' "$SUMMARY")
+          UPDATED=$(jq -r '.updatedVersions[]' "$SUMMARY")
+          NEW_COUNT=$(jq -r '.newVersions | length' "$SUMMARY")
+          UPDATED_COUNT=$(jq -r '.updatedVersions | length' "$SUMMARY")
+
+          NOTIFIABLE=""
+          while IFS= read -r version; do
+            [ -n "$version" ] || continue
+            clean_version="${version#v}"
+            clean_current="${CURRENT#v}"
+
+            if [ "$clean_version" != "$clean_current" ] && \
+              [ "$(printf '%s\n%s\n' "$clean_current" "$clean_version" | sort -V | tail -n1)" = "$clean_version" ]; then
+              NOTIFIABLE="${NOTIFIABLE} ${version}"
+            fi
+          done <<EOF
+          $NEW
+          EOF
+
+          CHANGED=$(printf '%s\n%s\n' "$NEW" "$UPDATED" | sed '/^$/d' | sort -uV)
+          SALVAGED=""
+          for file in apps/changelog-fetcher/changelogs/*.md; do
+            [ -e "$file" ] || continue
+            version=$(basename "$file" .md)
+            if [ ! -f "apps/changelog-fetcher/analysis/analysis_${version}.json" ] || \
+              [ ! -f "apps/changelog-fetcher/inferred/inferred_${version}.json" ]; then
+              SALVAGED="${SALVAGED} ${version}"
+            fi
+          done
+
+          CHANGED=$(printf '%s\n%s\n' "$CHANGED" "$SALVAGED" | sed '/^$/d' | sort -uV | xargs)
+          NOTIFIABLE=$(printf '%s\n' "$NOTIFIABLE" | tr ' ' '\n' | sed '/^$/d' | sort -uV | xargs)
+
+          if [ -z "$CHANGED" ]; then
+            {
+              echo "has_updates=false"
+              echo "has_notifiable=false"
+            } >> "$GITHUB_OUTPUT"
             echo "ℹ️ チェンジログに更新なし"
             exit 0
-          else
-            echo "has_updates=true" >> "$GITHUB_OUTPUT"
-
-            # ファイル名からバージョン抽出 (apps/changelog-fetcher/changelogs/vX.Y.Z.md → vX.Y.Z)
-            NEW_VERSIONS=$(echo "$CHANGED_FILES" | sed 's|apps/changelog-fetcher/changelogs/||' | sed 's|\.md$||' | tr '\n' ' ' | xargs)
-            echo "new_versions=$NEW_VERSIONS" >> "$GITHUB_OUTPUT"
-
-            echo "✅ チェンジログに更新あり"
-            echo "$CHANGED_FILES"
-            echo ""
-            echo "対象バージョン: $NEW_VERSIONS"
           fi
+
+          {
+            echo "has_updates=true"
+            if [ -n "$NOTIFIABLE" ]; then
+              echo "has_notifiable=true"
+            else
+              echo "has_notifiable=false"
+            fi
+            echo "changed_versions=$CHANGED"
+            echo "notifiable_versions=$NOTIFIABLE"
+            echo "new_count=$NEW_COUNT"
+            echo "updated_count=$UPDATED_COUNT"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "✅ チェンジログに更新あり"
+          echo "解析対象: $CHANGED"
+          echo "通知対象: ${NOTIFIABLE:-なし}"
 
       - name: Analyze changelogs
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
         run: |
-          for version in $NEW_VERSIONS; do
+          for version in $CHANGED_VERSIONS; do
             echo "🔍 Analyzing $version..."
             pnpm run analyze "$version"
           done
@@ -98,9 +148,9 @@ jobs:
       - name: Verify analysis files
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
         run: |
-          for version in $NEW_VERSIONS; do
+          for version in $CHANGED_VERSIONS; do
             if [ ! -f "apps/changelog-fetcher/analysis/analysis_${version}.json" ]; then
               echo "❌ Missing analysis file for $version"
               exit 1
@@ -112,9 +162,9 @@ jobs:
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
         run: |
-          for version in $NEW_VERSIONS; do
+          for version in $CHANGED_VERSIONS; do
             echo "🤖 Inferring benefits for $version..."
             pnpm run infer "$version"
           done
@@ -122,9 +172,9 @@ jobs:
       - name: Verify inferred files
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
         run: |
-          for version in $NEW_VERSIONS; do
+          for version in $CHANGED_VERSIONS; do
             if [ ! -f "apps/changelog-fetcher/inferred/inferred_${version}.json" ]; then
               echo "❌ Missing inferred file for $version"
               exit 1
@@ -139,13 +189,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update version
-        if: steps.detect-updates.outputs.has_updates == 'true'
+        if: steps.detect-updates.outputs.has_notifiable == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          NOTIFIABLE_VERSIONS: ${{ steps.detect-updates.outputs.notifiable_versions }}
         run: |
           chmod +x .github/scripts/update-version.sh
           # shellcheck disable=SC2086
-          .github/scripts/update-version.sh $NEW_VERSIONS
+          .github/scripts/update-version.sh $NOTIFIABLE_VERSIONS
 
       - name: Format code
         if: steps.detect-updates.outputs.has_updates == 'true'
@@ -155,16 +205,20 @@ jobs:
         id: pr-meta
         if: steps.detect-updates.outputs.has_updates == 'true'
         env:
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          CHANGED_VERSIONS: ${{ steps.detect-updates.outputs.changed_versions }}
+          NOTIFIABLE_VERSIONS: ${{ steps.detect-updates.outputs.notifiable_versions }}
+          NEW_COUNT: ${{ steps.detect-updates.outputs.new_count }}
+          UPDATED_COUNT: ${{ steps.detect-updates.outputs.updated_count }}
         run: |
-          VERSION_COUNT=$(echo "$NEW_VERSIONS" | wc -w | tr -d ' ')
-          FIRST_VERSION=$(echo "$NEW_VERSIONS" | awk '{print $1}')
+          FIRST_VERSION=$(echo "$CHANGED_VERSIONS" | awk '{print $1}')
+          TITLE="chore: CHANGELOG を更新 (新規 ${NEW_COUNT}, 過去更新 ${UPDATED_COUNT})"
 
           {
             echo "branch=chore/changelog-${FIRST_VERSION}"
-            echo "title=chore: CHANGELOGを更新 (${VERSION_COUNT} versions)"
+            echo "title=${TITLE}"
             echo "body<<EOF"
-            echo "対象バージョン: ${NEW_VERSIONS}"
+            echo "解析対象バージョン: ${CHANGED_VERSIONS}"
+            echo "通知対象バージョン: ${NOTIFIABLE_VERSIONS:-なし}"
             echo ""
             echo "自動更新時刻: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
             echo "EOF"
@@ -196,14 +250,14 @@ jobs:
           echo "✓ PR #${PR_NUMBER} をマージしました"
 
       - name: Trigger notification dispatch
-        if: steps.detect-updates.outputs.has_updates == 'true'
+        if: steps.detect-updates.outputs.has_notifiable == 'true'
         env:
           NOTIFICATION_WORKER_URL: ${{ secrets.NOTIFICATION_WORKER_URL }}
           DISPATCH_SECRET: ${{ secrets.DISPATCH_SECRET }}
-          NEW_VERSIONS: ${{ steps.detect-updates.outputs.new_versions }}
+          NOTIFIABLE_VERSIONS: ${{ steps.detect-updates.outputs.notifiable_versions }}
         run: |
           echo "📤 通知配信をトリガー..."
-          VERSIONS_JSON=$(echo "$NEW_VERSIONS" | tr ' ' '\n' | jq -R . | jq -s .)
+          VERSIONS_JSON=$(echo "$NOTIFIABLE_VERSIONS" | tr ' ' '\n' | jq -R . | jq -s .)
           curl -f -X POST "${NOTIFICATION_WORKER_URL}/api/dispatch" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${DISPATCH_SECRET}" \
@@ -218,7 +272,7 @@ jobs:
           ISSUE_SUMMARY: |
             CHANGELOGの取得・解析・推論処理に失敗しました。
 
-            **対象バージョン**: ${{ steps.detect-updates.outputs.new_versions }}
+            **対象バージョン**: ${{ steps.detect-updates.outputs.changed_versions }}
           ISSUE_LABELS: automated-failure,workflow:changelog-auto-inference,bug
         with:
           script: |

--- a/apps/changelog-fetcher/src/__tests__/classify-fetched-version.test.ts
+++ b/apps/changelog-fetcher/src/__tests__/classify-fetched-version.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { classifyFetchedVersion } from '../domain/changelog/classify-fetched-version';
+
+describe('取得済みバージョンの分類', () => {
+  it('ローカルファイルが存在しない時、新規として扱うこと', () => {
+    const result = classifyFetchedVersion({
+      remoteHash: 'remote-content-hash',
+      existingLocalHash: null,
+      existsLocally: false,
+    });
+
+    expect(result).toBe('new');
+  });
+
+  it('ローカルファイルが存在しハッシュが変わった時、更新として扱うこと', () => {
+    const result = classifyFetchedVersion({
+      remoteHash: 'remote-content-hash',
+      existingLocalHash: 'previous-content-hash',
+      existsLocally: true,
+    });
+
+    expect(result).toBe('updated');
+  });
+
+  it('ローカルファイルが存在しハッシュが同じ時、変更なしとして扱うこと', () => {
+    const result = classifyFetchedVersion({
+      remoteHash: 'same-content-hash',
+      existingLocalHash: 'same-content-hash',
+      existsLocally: true,
+    });
+
+    expect(result).toBe('unchanged');
+  });
+});

--- a/apps/changelog-fetcher/src/__tests__/merge-analysis-entries.test.ts
+++ b/apps/changelog-fetcher/src/__tests__/merge-analysis-entries.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type AnalyzedChangelogEntry,
+  createAnalyzedChangelogEntry,
+} from '../domain/analysis/analyzed-changelog-entry';
+import { createChangelogAnalysis } from '../domain/analysis/changelog-analysis';
+import { mergeAnalysisEntries } from '../domain/analysis/merge-analysis-entries';
+import type { ChangelogEntry } from '../domain/changelog/changelog-entry';
+import { createChangelogEntry } from '../domain/changelog/changelog-entry';
+import { createChangelogVersion } from '../domain/changelog/changelog-version';
+
+describe('解析済み項目の差分反映', () => {
+  it('既存解析がない時、現在の全項目を検索対象にすること', () => {
+    const currentEntries = [
+      changelogEntry('- Added plan mode support'),
+      changelogEntry('- Fixed resume from VS Code terminal'),
+    ];
+
+    const sut = mergeAnalysisEntries(currentEntries, null);
+
+    expect(sut.entriesNeedingSearch.map((entry) => entry.content)).toEqual([
+      '- Added plan mode support',
+      '- Fixed resume from VS Code terminal',
+    ]);
+  });
+
+  it('現在の項目が既存解析と同じ時、既存の関連ドキュメントを保持した解析結果を再構成できること', () => {
+    const currentEntries = [
+      changelogEntry('- Added plan mode support'),
+      changelogEntry('- Fixed resume from VS Code terminal'),
+    ];
+    const existingAnalysis = changelogAnalysis([
+      analyzedEntry('- Added plan mode support', 'docs/plan.md'),
+      analyzedEntry('- Fixed resume from VS Code terminal', 'docs/vs-code.md'),
+    ]);
+
+    const sut = mergeAnalysisEntries(currentEntries, existingAnalysis);
+
+    expect(filesFromMergeDecisions(sut.decisions, [])).toEqual([
+      'docs/plan.md',
+      'docs/vs-code.md',
+    ]);
+  });
+
+  it('末尾に項目が追加された時、追加項目だけを検索対象にして現在の順序で解析結果を再構成できること', () => {
+    const currentEntries = [
+      changelogEntry('- Added plan mode support'),
+      changelogEntry('- Fixed resume from VS Code terminal'),
+      changelogEntry('- Updated MCP server reconnect behavior'),
+    ];
+    const existingAnalysis = changelogAnalysis([
+      analyzedEntry('- Added plan mode support', 'docs/plan.md'),
+      analyzedEntry('- Fixed resume from VS Code terminal', 'docs/vs-code.md'),
+    ]);
+
+    const sut = mergeAnalysisEntries(currentEntries, existingAnalysis);
+    const searchedEntries = [
+      analyzedEntry('- Updated MCP server reconnect behavior', 'docs/mcp.md'),
+    ];
+
+    expect(sut.entriesNeedingSearch.map((entry) => entry.content)).toEqual([
+      '- Updated MCP server reconnect behavior',
+    ]);
+    expect(filesFromMergeDecisions(sut.decisions, searchedEntries)).toEqual([
+      'docs/plan.md',
+      'docs/vs-code.md',
+      'docs/mcp.md',
+    ]);
+  });
+
+  it('末尾から項目が削除された時、削除された解析項目を結果に残さないこと', () => {
+    const currentEntries = [changelogEntry('- Added plan mode support')];
+    const existingAnalysis = changelogAnalysis([
+      analyzedEntry('- Added plan mode support', 'docs/plan.md'),
+      analyzedEntry('- Removed old terminal behavior', 'docs/terminal.md'),
+    ]);
+
+    const sut = mergeAnalysisEntries(currentEntries, existingAnalysis);
+
+    expect(
+      sut.decisions.map((decision) =>
+        decision.kind === 'existing' ? decision.entry.content : undefined,
+      ),
+    ).toEqual(['- Added plan mode support']);
+  });
+
+  it('同じ本文の項目が複数ある時、本文だけでなく位置が一致した項目だけを流用すること', () => {
+    const duplicatedContent = '- Added settings validation';
+    const currentEntries = [
+      changelogEntry(duplicatedContent),
+      changelogEntry('- Fixed settings migration'),
+      changelogEntry(duplicatedContent),
+    ];
+    const existingAnalysis = changelogAnalysis([
+      analyzedEntry(duplicatedContent, 'docs/settings-first.md'),
+      analyzedEntry(duplicatedContent, 'docs/settings-second.md'),
+    ]);
+
+    const sut = mergeAnalysisEntries(currentEntries, existingAnalysis);
+    const searchedEntries = [
+      analyzedEntry('- Fixed settings migration', 'docs/settings-migration.md'),
+      analyzedEntry(duplicatedContent, 'docs/settings-new-position.md'),
+    ];
+
+    expect(sut.entriesNeedingSearch.map((entry) => entry.content)).toEqual([
+      '- Fixed settings migration',
+      duplicatedContent,
+    ]);
+    expect(filesFromMergeDecisions(sut.decisions, searchedEntries)).toEqual([
+      'docs/settings-first.md',
+      'docs/settings-migration.md',
+      'docs/settings-new-position.md',
+    ]);
+  });
+});
+
+function changelogEntry(value: string): ChangelogEntry {
+  return createChangelogEntry(value);
+}
+
+function analyzedEntry(
+  content: string,
+  relatedDocFile: string,
+): AnalyzedChangelogEntry {
+  const entry = changelogEntry(content);
+
+  return createAnalyzedChangelogEntry({
+    content: entry.content,
+    prefix: entry.prefix,
+    relatedDocs: [
+      { file: relatedDocFile, snippets: ['関連ドキュメント'], hitCount: 1 },
+    ],
+  });
+}
+
+function changelogAnalysis(items: AnalyzedChangelogEntry[]) {
+  return createChangelogAnalysis({
+    version: createChangelogVersion('v1.0.0'),
+    items,
+  });
+}
+
+function filesFromMergeDecisions(
+  decisions: ReturnType<typeof mergeAnalysisEntries>['decisions'],
+  searchedEntries: AnalyzedChangelogEntry[],
+): (string | undefined)[] {
+  return decisions.map((decision) => {
+    if (decision.kind === 'existing') {
+      return decision.entry.relatedDocs[0]?.file;
+    }
+
+    const searchedEntry = searchedEntries[decision.searchedIndex];
+    return searchedEntry?.relatedDocs[0]?.file;
+  });
+}

--- a/apps/changelog-fetcher/src/__tests__/transfer-existing-inference.test.ts
+++ b/apps/changelog-fetcher/src/__tests__/transfer-existing-inference.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type AnalyzedChangelogEntry,
+  createAnalyzedChangelogEntry,
+} from '../domain/analysis/analyzed-changelog-entry';
+import { createChangelogAnalysis } from '../domain/analysis/changelog-analysis';
+import { createChangelogEntry } from '../domain/changelog/changelog-entry';
+import { createChangelogVersion } from '../domain/changelog/changelog-version';
+import { createInferenceResult } from '../domain/inference/inference-result';
+import { findMissingInferenceItems } from '../usecase/inference-batch';
+import { transferExistingInference } from '../usecase/transfer-existing-inference';
+
+describe('既存推論の引き継ぎ', () => {
+  it('既存推論がない時、現在の解析結果を変更しないこと', () => {
+    const currentAnalysis = changelogAnalysis([
+      analyzedEntry('- Added plan mode support'),
+    ]);
+
+    const result = transferExistingInference(currentAnalysis, null);
+
+    expect(result).toEqual(currentAnalysis);
+  });
+
+  it('現在の項目が既存推論と同じ時、翻訳・推論・機能領域を引き継ぐこと', () => {
+    const currentAnalysis = changelogAnalysis([
+      analyzedEntry('- Added plan mode support'),
+      analyzedEntry('- Fixed resume from VS Code terminal'),
+    ]);
+    const existingInferred = changelogAnalysis([
+      inferredEntry(
+        '- Added plan mode support',
+        'プランモードが利用できるようになりました',
+        'Plan',
+      ),
+      inferredEntry(
+        '- Fixed resume from VS Code terminal',
+        'VS Code ターミナルからの再開問題を修正しました',
+        'IDE',
+      ),
+    ]);
+
+    const result = transferExistingInference(currentAnalysis, existingInferred);
+
+    expect(
+      result.items.map((item) => ({
+        contentJa: item.contentJa,
+        featureAreas: item.featureAreas,
+        benefit: item.inference?.benefit,
+      })),
+    ).toEqual([
+      {
+        contentJa: 'プランモードが利用できるようになりました',
+        featureAreas: ['Plan'],
+        benefit: '利用者は対象機能の恩恵をすぐ確認できます',
+      },
+      {
+        contentJa: 'VS Code ターミナルからの再開問題を修正しました',
+        featureAreas: ['IDE'],
+        benefit: '利用者は対象機能の恩恵をすぐ確認できます',
+      },
+    ]);
+    expect(findMissingInferenceItems(result)).toEqual([]);
+  });
+
+  it('末尾に項目が追加された時、追加項目だけを未推論として残すこと', () => {
+    const currentAnalysis = changelogAnalysis([
+      analyzedEntry('- Added plan mode support'),
+      analyzedEntry('- Updated MCP server reconnect behavior'),
+    ]);
+    const existingInferred = changelogAnalysis([
+      inferredEntry(
+        '- Added plan mode support',
+        'プランモードが利用できるようになりました',
+        'Plan',
+      ),
+    ]);
+
+    const result = transferExistingInference(currentAnalysis, existingInferred);
+
+    expect(result.items[0]?.contentJa).toBe(
+      'プランモードが利用できるようになりました',
+    );
+    expect(
+      findMissingInferenceItems(result).map((item) => item.entry.content),
+    ).toEqual(['- Updated MCP server reconnect behavior']);
+  });
+
+  it('末尾から項目が削除された時、削除された推論項目を結果に残さないこと', () => {
+    const currentAnalysis = changelogAnalysis([
+      analyzedEntry('- Added plan mode support'),
+    ]);
+    const existingInferred = changelogAnalysis([
+      inferredEntry(
+        '- Added plan mode support',
+        'プランモードが利用できるようになりました',
+        'Plan',
+      ),
+      inferredEntry(
+        '- Removed legacy terminal behavior',
+        '古いターミナル挙動が削除されました',
+        'Settings',
+      ),
+    ]);
+
+    const result = transferExistingInference(currentAnalysis, existingInferred);
+
+    expect(result.items.map((item) => item.content)).toEqual([
+      '- Added plan mode support',
+    ]);
+    expect(findMissingInferenceItems(result)).toEqual([]);
+  });
+});
+
+function analyzedEntry(content: string): AnalyzedChangelogEntry {
+  const entry = createChangelogEntry(content);
+
+  return createAnalyzedChangelogEntry({
+    content: entry.content,
+    prefix: entry.prefix,
+    relatedDocs: [
+      { file: 'docs/example.md', snippets: ['関連ドキュメント'], hitCount: 1 },
+    ],
+  });
+}
+
+function inferredEntry(
+  content: string,
+  contentJa: string,
+  featureArea: string,
+): AnalyzedChangelogEntry {
+  return createAnalyzedChangelogEntry({
+    ...analyzedEntry(content),
+    contentJa,
+    featureAreas: [featureArea],
+    inference: createInferenceResult({
+      before: '変更前は利用者が手作業で問題を避ける必要がありました',
+      after: '変更後は利用者が追加作業なしで同じ目的を達成できます',
+      benefit: '利用者は対象機能の恩恵をすぐ確認できます',
+    }),
+  });
+}
+
+function changelogAnalysis(items: AnalyzedChangelogEntry[]) {
+  return createChangelogAnalysis({
+    version: createChangelogVersion('v1.0.0'),
+    items,
+  });
+}

--- a/apps/changelog-fetcher/src/domain/analysis/merge-analysis-entries.ts
+++ b/apps/changelog-fetcher/src/domain/analysis/merge-analysis-entries.ts
@@ -1,0 +1,49 @@
+import type { ChangelogEntry } from '../changelog/changelog-entry';
+import type { AnalyzedChangelogEntry } from './analyzed-changelog-entry';
+import type { ChangelogAnalysis } from './changelog-analysis';
+
+export type AnalysisEntryMergeDecision =
+  | {
+      kind: 'existing';
+      entry: AnalyzedChangelogEntry;
+    }
+  | {
+      kind: 'searched';
+      searchedIndex: number;
+    };
+
+export type AnalysisMergeResult = {
+  entriesNeedingSearch: ChangelogEntry[];
+  decisions: AnalysisEntryMergeDecision[];
+};
+
+export function mergeAnalysisEntries(
+  currentEntries: ChangelogEntry[],
+  existingAnalysis: ChangelogAnalysis | null,
+): AnalysisMergeResult {
+  const entriesNeedingSearch: ChangelogEntry[] = [];
+  const decisions: AnalysisEntryMergeDecision[] = [];
+
+  for (const [index, entry] of currentEntries.entries()) {
+    const existingEntry = existingAnalysis?.items[index];
+
+    if (
+      existingEntry !== undefined &&
+      existingEntry.content === entry.content
+    ) {
+      decisions.push({ kind: 'existing', entry: existingEntry });
+      continue;
+    }
+
+    decisions.push({
+      kind: 'searched',
+      searchedIndex: entriesNeedingSearch.length,
+    });
+    entriesNeedingSearch.push(entry);
+  }
+
+  return {
+    entriesNeedingSearch,
+    decisions,
+  };
+}

--- a/apps/changelog-fetcher/src/domain/changelog/classify-fetched-version.ts
+++ b/apps/changelog-fetcher/src/domain/changelog/classify-fetched-version.ts
@@ -1,0 +1,20 @@
+type FetchedVersionClassification = 'new' | 'updated' | 'unchanged';
+
+export function classifyFetchedVersion(input: {
+  remoteHash: string;
+  existingLocalHash: string | null;
+  existsLocally: boolean;
+}): FetchedVersionClassification {
+  if (!input.existsLocally) {
+    return 'new';
+  }
+
+  if (
+    input.existingLocalHash === null ||
+    input.remoteHash !== input.existingLocalHash
+  ) {
+    return 'updated';
+  }
+
+  return 'unchanged';
+}

--- a/apps/changelog-fetcher/src/infer-benefits.ts
+++ b/apps/changelog-fetcher/src/infer-benefits.ts
@@ -4,6 +4,7 @@ import { getLogger, toError } from '@claude-code-changelog-viewer/common';
 import { AnalysisSchema } from '@claude-code-changelog-viewer/types';
 import { inferBenefits, type InferencePort } from './usecase/infer-benefits';
 import { GeminiInferenceClient } from './infrastructure/ai/gemini-inference-client';
+import { createInferredFileStore } from './infrastructure/filesystem/changelog-file-store';
 import {
   toAnalysisJson,
   toChangelogAnalysis,
@@ -31,16 +32,17 @@ function parseArgs(): CliArgs {
 
 async function main(): Promise<void> {
   const { version, skipAI } = parseArgs();
-  const analysisDir = join(process.cwd(), 'analysis');
-  const inferredDir = join(process.cwd(), 'inferred');
+  const appDir = process.cwd();
+  const analysisDir = join(appDir, 'analysis');
+  const inferredDir = join(appDir, 'inferred');
   const analysisPath = join(analysisDir, `analysis_${version}.json`);
   const inferredPath = join(inferredDir, `inferred_${version}.json`);
 
   log.msg('APLG0003', { params: [analysisPath] });
   const rawAnalysis = readFileSync(analysisPath, 'utf-8');
-  const analysis = toChangelogAnalysis(
-    AnalysisSchema.parse(JSON.parse(rawAnalysis)),
-  );
+  const parsedAnalysis = JSON.parse(rawAnalysis);
+  const analysisJson = AnalysisSchema.parse(parsedAnalysis);
+  const analysis = toChangelogAnalysis(analysisJson);
 
   const inference: InferencePort = skipAI
     ? {
@@ -53,12 +55,19 @@ async function main(): Promise<void> {
         log.child({ component: 'gemini' }),
       );
 
-  const inferred = toAnalysisJson(
-    await inferBenefits({ version, analysis, skipAI, inference }),
-  );
+  const store = createInferredFileStore(appDir);
+  const inferredAnalysis = await inferBenefits({
+    version,
+    analysis,
+    skipAI,
+    inference,
+    store,
+  });
+  const inferred = toAnalysisJson(inferredAnalysis);
 
   mkdirSync(inferredDir, { recursive: true });
-  writeFileSync(inferredPath, JSON.stringify(inferred, null, 2), 'utf-8');
+  const serializedInferred = JSON.stringify(inferred, null, 2);
+  writeFileSync(inferredPath, serializedInferred, 'utf-8');
   log.msg('APLG0021', { params: [inferredPath] });
 
   const completedCount = inferred.items.filter(

--- a/apps/changelog-fetcher/src/infrastructure/filesystem/changelog-file-store.ts
+++ b/apps/changelog-fetcher/src/infrastructure/filesystem/changelog-file-store.ts
@@ -1,11 +1,14 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { AnalysisSchema } from '@claude-code-changelog-viewer/types';
 import type {
   ChangelogMetadata,
   ChangelogStorePort,
+  FetchChangelogSummary,
 } from '../../usecase/fetch-changelog';
 import type { AnalysisStorePort } from '../../usecase/analyze-changelog';
+import type { InferredStorePort } from '../../usecase/infer-benefits';
 import type { ChangelogAnalysis } from '../../domain/analysis/changelog-analysis';
 import type { ChangelogDiffEvent } from '../../domain/changelog/changelog-diff-event';
 import type { ChangelogRelease } from '../../domain/changelog/changelog-release';
@@ -16,7 +19,10 @@ import {
 } from '../../domain/changelog/changelog-version';
 import type { ChangelogDiffEventType } from '../../domain/changelog/changelog-diff-event';
 import { parseChangelogReleases } from '../docs/changelog-markdown-parser';
-import { toAnalysisJson } from '../serializers/analysis-serializer';
+import {
+  toAnalysisJson,
+  toChangelogAnalysis,
+} from '../serializers/analysis-serializer';
 
 export type ChangelogDiffJson = {
   events: DiffEventJson[];
@@ -32,10 +38,32 @@ export type DiffEventJson = {
 
 export function createAnalysisFileStore(appDir: string): AnalysisStorePort {
   return {
+    async load(version: string): Promise<ChangelogAnalysis | null> {
+      const filename = `analysis_${version}.json`;
+      const filePath = join(appDir, 'analysis', filename);
+      const analysis = await loadAnalysisFile(filePath);
+
+      return analysis;
+    },
     async save(analysis: ChangelogAnalysis, version: string): Promise<void> {
       const output = toAnalysisJson(analysis);
-      const outputPath = join(appDir, 'analysis', `analysis_${version}.json`);
-      await writeFile(outputPath, JSON.stringify(output, null, 2));
+      const filename = `analysis_${version}.json`;
+      const outputPath = join(appDir, 'analysis', filename);
+      const serializedOutput = JSON.stringify(output, null, 2);
+
+      await writeFile(outputPath, serializedOutput);
+    },
+  };
+}
+
+export function createInferredFileStore(appDir: string): InferredStorePort {
+  return {
+    async load(version: string): Promise<ChangelogAnalysis | null> {
+      const filename = `inferred_${version}.json`;
+      const filePath = join(appDir, 'inferred', filename);
+      const analysis = await loadAnalysisFile(filePath);
+
+      return analysis;
     },
   };
 }
@@ -43,11 +71,13 @@ export function createAnalysisFileStore(appDir: string): AnalysisStorePort {
 export class ChangelogFileStore implements ChangelogStorePort {
   #outputDir: string;
   #metadataFile: string;
+  #summaryFile: string;
   #diffFile: string;
 
   constructor(appDir: string) {
     this.#outputDir = join(appDir, 'changelogs');
     this.#metadataFile = join(appDir, 'metadata', 'last_fetch.json');
+    this.#summaryFile = join(appDir, 'metadata', 'last_fetch_summary.json');
     this.#diffFile = join(appDir, 'diff', 'changelog_diff.json');
   }
 
@@ -56,9 +86,10 @@ export class ChangelogFileStore implements ChangelogStorePort {
       return { lastFetchTime: '', versions: {} };
     }
 
-    return JSON.parse(
-      await readFile(this.#metadataFile, 'utf-8'),
-    ) as ChangelogMetadata;
+    const rawMetadata = await readFile(this.#metadataFile, 'utf-8');
+    const metadata = JSON.parse(rawMetadata) as ChangelogMetadata;
+
+    return metadata;
   }
 
   async saveMetadata(metadata: ChangelogMetadata): Promise<void> {
@@ -70,15 +101,33 @@ export class ChangelogFileStore implements ChangelogStorePort {
     );
   }
 
+  async deleteFetchSummary(): Promise<void> {
+    await rm(this.#summaryFile, { force: true });
+  }
+
+  async saveFetchSummary(summary: FetchChangelogSummary): Promise<void> {
+    await mkdir(dirname(this.#summaryFile), { recursive: true });
+    await writeFile(
+      this.#summaryFile,
+      `${JSON.stringify(summary, null, 2)}\n`,
+      'utf-8',
+    );
+  }
+
   async loadDiffEvents(): Promise<ChangelogDiffEvent[]> {
     const data = await loadChangelogDiffFile(this.#diffFile);
-    return data.events.map(toDomainDiffEvent);
+    const events = data.events.map(toDomainDiffEvent);
+
+    return events;
   }
 
   async saveDiffEvents(events: ChangelogDiffEvent[]): Promise<void> {
-    await saveChangelogDiffFile(this.#diffFile, {
-      events: events.map(toDiffEventJson),
-    });
+    const diffEvents = events.map(toDiffEventJson);
+    const data = {
+      events: diffEvents,
+    };
+
+    await saveChangelogDiffFile(this.#diffFile, data);
   }
 
   async loadRelease(
@@ -90,17 +139,20 @@ export class ChangelogFileStore implements ChangelogStorePort {
     }
 
     const markdown = await readFile(filePath, 'utf-8');
-    return parseChangelogReleases(markdown)[0] ?? null;
+    const releases = parseChangelogReleases(markdown);
+    const release = releases[0] ?? null;
+
+    return release;
   }
 
   async saveRelease(release: ChangelogRelease): Promise<void> {
     await mkdir(this.#outputDir, { recursive: true });
     const versionNumber = toVersionNumber(release.version);
-    await writeFile(
-      join(this.#outputDir, toVersionFilename(release.version)),
-      `## ${versionNumber}\n\n${release.content}\n`,
-      'utf-8',
-    );
+    const filename = toVersionFilename(release.version);
+    const filePath = join(this.#outputDir, filename);
+    const markdown = `## ${versionNumber}\n\n${release.content}\n`;
+
+    await writeFile(filePath, markdown, 'utf-8');
   }
 }
 
@@ -111,7 +163,10 @@ export async function loadChangelogDiffFile(
     return { events: [] };
   }
 
-  return JSON.parse(await readFile(filePath, 'utf-8')) as ChangelogDiffJson;
+  const rawData = await readFile(filePath, 'utf-8');
+  const data = JSON.parse(rawData) as ChangelogDiffJson;
+
+  return data;
 }
 
 export async function saveChangelogDiffFile(
@@ -144,4 +199,19 @@ function toDiffEventJson(event: ChangelogDiffEvent): DiffEventJson {
 
 function toVersionFilename(version: ChangelogVersion): string {
   return `${version}.md`;
+}
+
+async function loadAnalysisFile(
+  filePath: string,
+): Promise<ChangelogAnalysis | null> {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  const rawAnalysis = await readFile(filePath, 'utf-8');
+  const parsedAnalysis = JSON.parse(rawAnalysis);
+  const analysisJson = AnalysisSchema.parse(parsedAnalysis);
+  const analysis = toChangelogAnalysis(analysisJson);
+
+  return analysis;
 }

--- a/apps/changelog-fetcher/src/parse-changelog.ts
+++ b/apps/changelog-fetcher/src/parse-changelog.ts
@@ -12,10 +12,14 @@ const log = getLogger({ name: 'changelog-fetcher' });
 
 async function main(): Promise<void> {
   const appDir = join(__dirname, '..');
+  const store = new ChangelogFileStore(appDir);
+
+  await store.deleteFetchSummary();
   const result = await fetchChangelog({
     source: new ClaudeCodeChangelogClient(),
-    store: new ChangelogFileStore(appDir),
+    store,
   });
+  await store.saveFetchSummary(result.summary);
 
   if (result.newCount === 0 && result.updatedCount === 0) {
     log.msg('APLG0008', { params: ['CHANGELOG'] });

--- a/apps/changelog-fetcher/src/usecase/analyze-changelog.ts
+++ b/apps/changelog-fetcher/src/usecase/analyze-changelog.ts
@@ -4,6 +4,7 @@ import {
   createChangelogAnalysis,
   type ChangelogAnalysis,
 } from '../domain/analysis/changelog-analysis';
+import { mergeAnalysisEntries } from '../domain/analysis/merge-analysis-entries';
 import type { RelatedDoc } from '../domain/analysis/related-doc';
 import type { ChangelogEntry } from '../domain/changelog/changelog-entry';
 import { createChangelogVersion } from '../domain/changelog/changelog-version';
@@ -15,6 +16,7 @@ export type DocsSearchPort = {
 };
 
 export type AnalysisStorePort = {
+  load: (version: string) => Promise<ChangelogAnalysis | null>;
   save: (analysis: ChangelogAnalysis, version: string) => Promise<void>;
 };
 
@@ -29,10 +31,18 @@ export async function analyzeChangelog(input: {
 
   log.msg('APLG0010', { params: [`${entries.length} 件の項目`] });
 
-  const items = await Promise.all(
-    entries.map(async (entry, index) => {
+  const merged = mergeAnalysisEntries(
+    entries,
+    await input.store.load(input.version),
+  );
+  log.info('既存 analysis の差分マージ', {
+    needsSearch: merged.entriesNeedingSearch.length,
+  });
+
+  const searched = await Promise.all(
+    merged.entriesNeedingSearch.map(async (entry, index) => {
       log.info(
-        `[${index + 1}/${entries.length}] ${entry.content.slice(0, 60)}...`,
+        `[${index + 1}/${merged.entriesNeedingSearch.length}] ${entry.content.slice(0, 60)}...`,
       );
 
       const relatedDocs = await input.docsSearch.findRelatedDocs(entry);
@@ -45,6 +55,18 @@ export async function analyzeChangelog(input: {
     }),
   );
 
+  const items = merged.decisions.map((decision) => {
+    if (decision.kind === 'existing') {
+      return decision.entry;
+    }
+
+    const searchedEntry = searched[decision.searchedIndex];
+    if (searchedEntry === undefined) {
+      throw new Error('検索済み analysis 項目が不足しています');
+    }
+
+    return searchedEntry;
+  });
   const analysis = createChangelogAnalysis({ version, items });
   await input.store.save(analysis, input.version);
   return analysis;

--- a/apps/changelog-fetcher/src/usecase/fetch-changelog.ts
+++ b/apps/changelog-fetcher/src/usecase/fetch-changelog.ts
@@ -7,6 +7,7 @@ import {
   isDuplicateDiffEvent,
   type ChangelogDiffEvent,
 } from '../domain/changelog/changelog-diff-event';
+import { classifyFetchedVersion } from '../domain/changelog/classify-fetched-version';
 import type { ChangelogRelease } from '../domain/changelog/changelog-release';
 import {
   createChangelogVersion,
@@ -36,6 +37,14 @@ export type ChangelogStorePort = {
 export type FetchChangelogResult = {
   newCount: number;
   updatedCount: number;
+  summary: FetchChangelogSummary;
+};
+
+export type FetchChangelogSummary = {
+  fetchedAt: string;
+  newVersions: string[];
+  updatedVersions: string[];
+  removedVersions: string[];
 };
 
 export async function fetchChangelog(input: {
@@ -53,6 +62,9 @@ export async function fetchChangelog(input: {
 
   let newCount = 0;
   let updatedCount = 0;
+  const newVersions: string[] = [];
+  const updatedVersions: string[] = [];
+  const removedVersions: string[] = [];
   const newMetadata: Record<string, string> = {};
   const remoteVersionKeys = new Set<string>();
 
@@ -63,10 +75,15 @@ export async function fetchChangelog(input: {
     const contentHash = createHash('sha256')
       .update(release.content, 'utf-8')
       .digest('hex');
-    const existingHash = existingMetadata.versions[versionKey] ?? '';
+    const existingHash = existingMetadata.versions[versionKey] ?? null;
     const localRelease = await input.store.loadRelease(release.version);
+    const classification = classifyFetchedVersion({
+      remoteHash: contentHash,
+      existingLocalHash: existingHash,
+      existsLocally: localRelease !== null,
+    });
 
-    if (contentHash !== existingHash && localRelease) {
+    if (classification === 'updated' && localRelease) {
       const diff = computeChangelogEntryDiff(
         localRelease.entries,
         release.entries,
@@ -87,7 +104,7 @@ export async function fetchChangelog(input: {
       }
     }
 
-    if (contentHash === existingHash && localRelease) {
+    if (classification === 'unchanged') {
       log.debug(`${versionKey}: 変更なし`);
       newMetadata[versionKey] = contentHash;
       continue;
@@ -95,12 +112,14 @@ export async function fetchChangelog(input: {
 
     await input.store.saveRelease(release);
 
-    if (existingHash) {
+    if (classification === 'updated') {
       log.info(`${versionKey}: 更新あり`);
       updatedCount += 1;
+      updatedVersions.push(versionKey);
     } else {
       log.info(`${versionKey}: 新規`);
       newCount += 1;
+      newVersions.push(versionKey);
     }
 
     newMetadata[versionKey] = contentHash;
@@ -115,6 +134,7 @@ export async function fetchChangelog(input: {
       detectedAt,
       version: createChangelogVersion(metadataVersionKey),
     });
+    removedVersions.push(metadataVersionKey);
 
     if (!isDuplicateDiffEvent(diffEvents, candidate)) {
       diffEvents.push(candidate);
@@ -130,5 +150,14 @@ export async function fetchChangelog(input: {
 
   log.msg('APLG0002', { params: ['CHANGELOG の取得'] });
 
-  return { newCount, updatedCount };
+  return {
+    newCount,
+    updatedCount,
+    summary: {
+      fetchedAt: detectedAt.toISOString(),
+      newVersions,
+      updatedVersions,
+      removedVersions,
+    },
+  };
 }

--- a/apps/changelog-fetcher/src/usecase/infer-benefits.ts
+++ b/apps/changelog-fetcher/src/usecase/infer-benefits.ts
@@ -7,6 +7,7 @@ import {
   type IndexedAnalyzedEntry,
   type InferenceBatch,
 } from './inference-batch';
+import { transferExistingInference } from './transfer-existing-inference';
 
 const log = getLogger({ name: 'benefit-inferrer' });
 
@@ -17,11 +18,16 @@ export type InferencePort = {
   }) => Promise<InferenceBatch>;
 };
 
+export type InferredStorePort = {
+  load: (version: string) => Promise<ChangelogAnalysis | null>;
+};
+
 export async function inferBenefits(input: {
   version: string;
   analysis: ChangelogAnalysis;
   skipAI: boolean;
   inference: InferencePort;
+  store: InferredStorePort;
 }): Promise<ChangelogAnalysis> {
   if (input.skipAI) {
     log.info('AI推論をスキップ (コピーモード)', {
@@ -35,16 +41,24 @@ export async function inferBenefits(input: {
     attrs: { totalItems: input.analysis.items.length },
   });
 
-  let analysis = applyInferenceBatch(
+  let analysis = transferExistingInference(
     input.analysis,
-    await input.inference.infer({
-      version: input.version,
-      items: input.analysis.items.map((entry, originalIndex) => ({
-        entry,
-        originalIndex,
-      })),
-    }),
+    await input.store.load(input.version),
   );
+  const missingBeforeInitial = findMissingInferenceItems(analysis);
+
+  if (missingBeforeInitial.length === 0) {
+    log.info('既存 inferred を全項目に流用したため AI推論をスキップ');
+    return analysis;
+  }
+
+  analysis = applyInferenceBatch(analysis, {
+    ...(await input.inference.infer({
+      version: input.version,
+      items: missingBeforeInitial,
+    })),
+    ...(analysis.summary !== undefined ? { summary: analysis.summary } : {}),
+  });
   log.msg('APLG0002', { params: ['バージョンサマリー生成'] });
 
   const missingAfterInitial = findMissingInferenceItems(analysis);
@@ -64,13 +78,15 @@ export async function inferBenefits(input: {
       }
 
       try {
-        analysis = applyInferenceBatch(
-          analysis,
-          await input.inference.infer({
+        analysis = applyInferenceBatch(analysis, {
+          ...(await input.inference.infer({
             version: input.version,
             items: missing,
-          }),
-        );
+          })),
+          ...(analysis.summary !== undefined
+            ? { summary: analysis.summary }
+            : {}),
+        });
       } catch (error) {
         throw new AbortError(
           error instanceof Error ? error.message : String(error),

--- a/apps/changelog-fetcher/src/usecase/transfer-existing-inference.ts
+++ b/apps/changelog-fetcher/src/usecase/transfer-existing-inference.ts
@@ -1,0 +1,42 @@
+import { createAnalyzedChangelogEntry } from '../domain/analysis/analyzed-changelog-entry';
+import {
+  type ChangelogAnalysis,
+  createChangelogAnalysis,
+} from '../domain/analysis/changelog-analysis';
+
+export function transferExistingInference(
+  currentAnalysis: ChangelogAnalysis,
+  existingInferred: ChangelogAnalysis | null,
+): ChangelogAnalysis {
+  if (existingInferred === null) {
+    return currentAnalysis;
+  }
+
+  return createChangelogAnalysis({
+    version: currentAnalysis.version,
+    ...((currentAnalysis.summary ?? existingInferred.summary) !== undefined
+      ? { summary: currentAnalysis.summary ?? existingInferred.summary }
+      : {}),
+    items: currentAnalysis.items.map((entry, index) => {
+      const existingEntry = existingInferred.items[index];
+
+      if (
+        existingEntry === undefined ||
+        existingEntry.content !== entry.content
+      ) {
+        return entry;
+      }
+
+      return createAnalyzedChangelogEntry({
+        ...entry,
+        ...(existingEntry.contentJa !== undefined
+          ? { contentJa: existingEntry.contentJa }
+          : {}),
+        featureAreas: existingEntry.featureAreas,
+        ...(existingEntry.inference !== undefined
+          ? { inference: existingEntry.inference }
+          : {}),
+      });
+    }),
+  });
+}


### PR DESCRIPTION
## 概要
- fetcher が `last_fetch_summary.json` に new / updated / removed の事実だけを書き出すようにしました
- analysis / inferred を index + content 一致で差分反映し、既存項目の再検索・再推論を避けるようにしました
- workflow の通知・version 更新対象を summary + `claude-version.json` の semver 比較で決めるようにしました

## 変更内容
- ドメイン純関数3本と出力値ベースの単体テストを追加
- `analyzeChangelog` / `inferBenefits` を既存結果の差分利用に対応
- filesystem store に summary 保存と analysis / inferred load を追加
- `changelog-auto-inference.yml` の検出・分析・推論・通知対象を整理

## 検証
- `pnpm run --filter changelog-fetcher test`
- `pnpm run ai-check`
- `actionlint .github/workflows/changelog-auto-inference.yml`
- `ghalint run --config .github/ghalint.yaml`
- `pinact run --check`

Closes #334